### PR TITLE
CI: improve automatic publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Upload Python Package
+name: Upload Python Package and Docker Container
 
 on:
   release:
@@ -6,9 +6,7 @@ on:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
 
@@ -20,36 +18,42 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install poetry
 
-    - name: Set __version__
+    - name: Set __version__ and poetry version
       run: |
-        echo "__version__ = \"${GITHUB_REF##*/}\"" > asu/__init__.py
+        TAG="$(git describe --tags --abbrev=0)"
+        echo "TAG=$TAG" >> "$GITHUB_ENV"
+        echo "__version__ = \"$TAG\"" > asu/__init__.py
+        poetry version "$TAG"
 
     - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        poetry build
+        poetry publish \
+          --username  ${{ secrets.PYPI_USERNAME }} \
+          --password ${{ secrets.PYPI_PASSWORD }}
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Push ASU server to Docker Hub
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: aparcar/asu-server
-        tag_with_ref: true
-        tags: latest
-        dockerfile: Dockerfile.server
+        tags: |
+          aparcar/asu-server:latest
+          aparcar/asu-server:$TAG
+        file: Dockerfile.server
+        push: true
 
     - name: Push ASU worker to Docker Hub
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: aparcar/asu-worker
-        tag_with_ref: true
-        tags: latest
-        dockerfile: Dockerfile.worker
+        tags: |
+          aparcar/asu-worker:latest
+          aparcar/asu-worker:$TAG
+        file: Dockerfile.worker
+        push: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ PyNaCl = "^1.5.0"
 redis = "^4.1.1"
 requests = "^2.27.1"
 rq = "^1.10.1"
-connexion = "^2.10.0"
+connexion = {extras = ["swagger-ui"], version = "^2.12.0"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asu"
-version = "0.6.4"
+version = "0.0.0"
 description = "An image on demand server for OpenWrt based distributions"
 authors = ["Paul Spooren <mail@aparcar.org>"]
 license = "GPL-2.0"


### PR DESCRIPTION
The building and publishing changed with poetry. Reflect that in the
publish CI job and while at it, update the used Docker creation actions.

Signed-off-by: Paul Spooren <mail@aparcar.org>