### PR TITLE
meta: don't use OpenWrt CDN

### DIFF
--- a/asu/asu.py
+++ b/asu/asu.py
@@ -31,7 +31,7 @@ def create_app(test_config: dict = None) -> Flask:
         REDIS_CONN=Redis(host=redis_host, port=redis_port, password=redis_password),
         TESTING=False,
         DEBUG=False,
-        UPSTREAM_URL="https://downloads.cdn.openwrt.org",
+        UPSTREAM_URL="https://downloads.openwrt.org",
         BRANCHES={},
         ALLOW_DEFAULTS=False,
     )

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -97,7 +97,7 @@ def test_build_real(app, httpserver: HTTPServer):
         },
         target="ath79/generic",
         store_path=app.config["STORE_PATH"],
-        upstream_url="https://downloads.cdn.openwrt.org",
+        upstream_url="https://downloads.openwrt.org",
         version="SNAPSHOT",
         profile="tplink_tl-wdr4300-v1",
         packages={"tmux", "vim"},


### PR DESCRIPTION
The CDN does not work reliably with snapshot builds as they frequently
change. Disable it for tests, a clean upstream solution should be
implemented where snapshots are stored at a different place than our
release builds.

Signed-off-by: Paul Spooren <mail@aparcar.org>