### PR TITLE
CI: test pull requests

### DIFF
--- a/.github/workflows/test.py
+++ b/.github/workflows/test.py
@@ -1,6 +1,6 @@
-name: Python application
+name: Test Pull Request
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:
@@ -8,15 +8,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
     name: Python ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Install ImageBuilder prereqs
-
       run: sudo apt-get install -y libncurses5-dev
+
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
By moving from aparcar/ to openwrt/ the CI must be triggered on
`pull_request` and no longer on `push`. While at it improve the
style/naming a little bit.

Signed-off-by: Paul Spooren <mail@aparcar.org>