### PR TITLE
CI: fix typo and double publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,6 @@ on:
   release:
     types:
       - created
-  push:
-    tags:
-      - "v*"
 
 jobs:
   deploy:
@@ -41,7 +38,7 @@ jobs:
         id: meta_server
         uses: docker/metadata-action@v3
         with:
-          images: aparcar/asu-worker
+          images: aparcar/asu-server
           tags: |
             type=semver,pattern={{version}}
 


### PR DESCRIPTION
Typo in meta job would cause upload of server container to worker image
name. Secondly publishing on tags and releases triggers two jobs at once
which fail since a Pypi package can be only uploaded once.

Signed-off-by: Paul Spooren <mail@aparcar.org>