### PR TITLE
CI: fix typo of PR test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test Pull Request
 
-on: [pull_request]
+on:
+  - push
+  - pull_request
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+
     name: Python ${{ matrix.python-version }}
 
     steps:


### PR DESCRIPTION
The test file was wrongly renamed to `test.py` instead of `test.yml`.
Test also on pushes to have the CI badge green.

Signed-off-by: Paul Spooren <mail@aparcar.org>