### PR TITLE
docker: mount worker to main asu-service/

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,7 @@ services:
   worker:
     image: "aparcar/asu-worker:latest"
     volumes:
-      - "./asu-service/public:/home/build/asu/public"
-      - "./asu-service/cache:/home/build/asu/cache"
+      - "./asu-service/:/home/build/asu/"
     depends_on:
       - redis
 
@@ -40,4 +39,4 @@ services:
       - "./misc/Caddyfile:/etc/caddy/Caddyfile"
       - "./asu-service:/site/"
     ports:
-      - "8080:80"
+      - "8000:80"


### PR DESCRIPTION
If mounting to sub-folders they will be created by Docker and ergo owned
by `root`, which breaks ASU services since they run as regular users.

Also fixup port mismatch between docker-compose and README.

Signed-off-by: Paul Spooren <mail@aparcar.org>