### PR TITLE
build: reset active filesystem after each build

### DIFF
--- a/asu/openapi.yml
+++ b/asu/openapi.yml
@@ -253,6 +253,8 @@ components:
           enum:
             - squashfs
             - ext4
+            - ubifs
+            - jffs2
           description: |
             Ability to specify filesystem running on device. Attaching this
             optional parameter will limit the ImageBuilder to only build


### PR DESCRIPTION
The active filesystem was wrongly only set on initial imagebuilder setup
instead of every time an image is build. This was due to the initial
implementation which would disable ext4 in general instead of disabling
filesystems specifically per request.

Now also support JFFS2 and UBIFS filesystems.

Signed-off-by: Paul Spooren <mail@aparcar.org>