### PR TITLE
stats: store cache hits

### DIFF
--- a/asu/api.py
+++ b/asu/api.py
@@ -263,6 +263,7 @@ def api_v1_build_post():
     failure_ttl = "12h"
 
     if job is None:
+        get_redis().incr("stats-cache-miss")
         response, status = validate_request(req)
         if response:
             return response, status
@@ -281,6 +282,9 @@ def api_v1_build_post():
             failure_ttl=failure_ttl,
             job_timeout="10m",
         )
+    else:
+        if job.is_finished:
+            get_redis().incr("stats-cache-hit")
 
     return return_job_v1(job)
 

--- a/asu/metrics.py
+++ b/asu/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client.core import CounterMetricFamily
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
 
 class BuildCollector(object):
@@ -15,3 +15,22 @@ class BuildCollector(object):
             stats_builds.add_metric(build.decode().split("#"), count)
 
         yield stats_builds
+
+        hits = self.connection.get("stats-cache-hit")
+        if hits:
+            hits = int(hits.decode())
+        else:
+            hits = 0
+
+        yield GaugeMetricFamily("cache_hits", "Cache hits of build images", value=hits)
+
+        misses = self.connection.get("stats-cache-miss")
+
+        if misses:
+            misses = int(misses.decode())
+        else:
+            misses = 0
+
+        yield GaugeMetricFamily(
+            "cache_misses", "Cache misses of build images in percent", value=misses
+        )

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -39,3 +39,36 @@ def test_stats_image_builds(client, upstream):
         'builds_total{branch="TESTVERSION",profile="testprofile",target="testtarget/testsubtarget",version="TESTVERSION"} 2.0'
         in response.get_data(as_text=True)
     )
+
+
+def test_stats_cache(client, upstream):
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            version="TESTVERSION",
+            target="testtarget/testsubtarget",
+            profile="testprofile",
+            packages=["test1", "test2"],
+        ),
+    )
+    assert response.status == "200 OK"
+    assert response.json.get("request_hash") == "33377fbd91c50c4236343f1dfd67f9ae"
+
+    response = client.get("/metrics")
+    print(response.get_data(as_text=True))
+    assert "cache_hits 0.0" in response.get_data(as_text=True)
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            version="TESTVERSION",
+            target="testtarget/testsubtarget",
+            profile="testprofile",
+            packages=["test1", "test2"],
+        ),
+    )
+    assert response.status == "200 OK"
+    assert response.json.get("request_hash") == "33377fbd91c50c4236343f1dfd67f9ae"
+
+    response = client.get("/metrics")
+    print(response.get_data(as_text=True))
+    assert "cache_hits 1.0" in response.get_data(as_text=True)


### PR DESCRIPTION
Start storing if images are always freshly requested or ever found in
cache. If a image is still building, don't change anything about the
cache since e.g. the firmware selector keeps posting full image requsts
which would increase the cache hits to non-sense.

Signed-off-by: Paul Spooren <mail@aparcar.org>