### PR TITLE
handle virtual packages defined in PROVIDES

### DIFF
--- a/asu/janitor.py
+++ b/asu/janitor.py
@@ -173,6 +173,17 @@ def update_target_packages(branch: dict, version: str, target: str):
 
     r.sadd(f"packages-{branch['name']}-{version}-{target}", *list(packages.keys()))
 
+    virtual_packages = {
+        vpkg.split("=")[0]
+        for pkg in packages.values()
+        if (provides := pkg.get("provides"))
+        for vpkg in provides.split(", ")
+    }
+    r.sadd(
+        f"packages-{branch['name']}-{version}-{target}",
+        *(virtual_packages | packages.keys()),
+    )
+
     output_path = current_app.config["JSON_PATH"] / version_path / "targets" / target
     output_path.mkdir(exist_ok=True, parents=True)
 
@@ -242,6 +253,14 @@ def update_arch_packages(branch: dict, arch: str):
 
     current_app.logger.info(f"{arch}: found {len(package_index.keys())} packages")
     r.sadd(f"packages-{branch['name']}-{arch}", *package_index.keys())
+
+    virtual_packages = {
+        vpkg.split("=")[0]
+        for pkg in packages.values()
+        if (provides := pkg.get("provides"))
+        for vpkg in provides.split(", ")
+    }
+    r.sadd(f"packages-{branch['name']}-{arch}", *(virtual_packages | packages.keys()))
 
 
 def update_target_profiles(branch: dict, version: str, target: str):


### PR DESCRIPTION
Those packages like nftables are requested by devices but don't exists
as an actual package.

FIXES: https://github.com/openwrt/asu/issues/344

Suggested-by: Justin Klaassen
Signed-off-by: Paul Spooren <mail@aparcar.org>