### PR TITLE
cleanup legacy package store based on target only

### DIFF
--- a/asu/janitor.py
+++ b/asu/janitor.py
@@ -194,7 +194,6 @@ def update_target_packages(branch: dict, version: str, target: str):
     )
 
     current_app.logger.info(f"{version}: found {len(package_index.keys())} packages")
-    r.sadd(f"packages-{branch['name']}-{version}", *package_index.keys())
 
 
 def update_arch_packages(branch: dict, arch: str):


### PR DESCRIPTION
The target is relevant, too. Don't store it just for the version.

Signed-off-by: Paul Spooren <mail@aparcar.org>