### PR TITLE
api: allow clients to send their identification

### DIFF
--- a/asu/api.py
+++ b/asu/api.py
@@ -262,6 +262,17 @@ def api_v1_build_post():
     result_ttl = "7d"
     failure_ttl = "12h"
 
+    if "client" in req:
+        get_redis().hincrby("stats:clients", req["client"])
+    else:
+        if request.headers.get("user-agent").startswith("auc"):
+            get_redis().hincrby(
+                "stats:clients",
+                request.headers.get("user-agent").replace(" (", "/").replace(")", ""),
+            )
+        else:
+            get_redis().hincrby("stats:clients", "unknown/0")
+
     if job is None:
         get_redis().incr("stats:cache-miss")
         response, status = validate_request(req)

--- a/asu/metrics.py
+++ b/asu/metrics.py
@@ -16,6 +16,16 @@ class BuildCollector(object):
 
         yield stats_builds
 
+        stats_clients = CounterMetricFamily(
+            "clients",
+            "Clients requesting images",
+            labels=["name", "version"],
+        )
+        for client, count in self.connection.hgetall("stats:clients").items():
+            stats_clients.add_metric(client.decode().split("/"), count)
+
+        yield stats_clients
+
         hits = self.connection.get("stats:cache-hit")
         if hits:
             hits = int(hits.decode())

--- a/asu/openapi.yml
+++ b/asu/openapi.yml
@@ -186,6 +186,11 @@ components:
       type: object
       additionalProperties: false
       properties:
+        client:
+          type: string
+          example: luci - git-22.073.39928-701ea94
+          description: |
+            Client name and version that requests the image,
         distro:
           type: string
           example: openwrt

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -73,3 +73,78 @@ def test_stats_cache(client, upstream):
     response = client.get("/metrics")
     print(response.get_data(as_text=True))
     assert "cache_hits 1.0" in response.get_data(as_text=True)
+
+
+def test_stats_clients_luci(client, upstream):
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            version="TESTVERSION",
+            target="testtarget/testsubtarget",
+            profile="testprofile",
+            packages=["test1", "test2"],
+            client="luci/git-22.073.39928-701ea94",
+        ),
+    )
+
+    response = client.get("/metrics")
+    print(response.get_data(as_text=True))
+    assert (
+        'clients_total{name="luci",version="git-22.073.39928-701ea94"} 1.0'
+        in response.get_data(as_text=True)
+    )
+
+
+def test_stats_clients_unknown(client, upstream):
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            version="TESTVERSION",
+            target="testtarget/testsubtarget",
+            profile="testprofile",
+            packages=["test1", "test2"],
+        ),
+    )
+
+    response = client.get("/metrics")
+    print(response.get_data(as_text=True))
+    assert 'clients_total{name="unknown",version="0"} 1.0' in response.get_data(
+        as_text=True
+    )
+
+
+def test_stats_clients_auc(client, upstream):
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            version="TESTVERSION",
+            target="testtarget/testsubtarget",
+            profile="testprofile",
+            packages=["test1", "test2"],
+        ),
+        headers={"User-Agent": "auc (0.3.2)"},
+    )
+
+    response = client.get("/metrics")
+    print(response.get_data(as_text=True))
+    assert 'clients_total{name="auc",version="0.3.2"} 1.0' in response.get_data(
+        as_text=True
+    )
+
+def test_stats_clients_auc_possible_new_format(client, upstream):
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            version="TESTVERSION",
+            target="testtarget/testsubtarget",
+            profile="testprofile",
+            packages=["test1", "test2"],
+        ),
+        headers={"User-Agent": "auc/0.3.2"},
+    )
+
+    response = client.get("/metrics")
+    print(response.get_data(as_text=True))
+    assert 'clients_total{name="auc",version="0.3.2"} 1.0' in response.get_data(
+        as_text=True
+    )


### PR DESCRIPTION
This allows to track the clients used to request updates. Ideally this help to
identify what versions are mostly used and drop support for outdated version.

A client can now send the "client" field in the format "name - version".

Signed-off-by: Paul Spooren <mail@aparcar.org>