### PR TITLE
api: drop server side handling of package_changes

### DIFF
--- a/asu/api.py
+++ b/asu/api.py
@@ -86,18 +86,6 @@ def validate_packages(req):
 
     req["packages"] = tr
 
-    if req.get("diff_packages", False):
-        for package, change in (
-            current_app.config["BRANCHES"][req["branch"]]
-            .get("package_changes", {})
-            .items()
-        ):
-            if package in req["packages"]:
-                current_app.logger.debug("changes to package %s", package)
-                req["packages"].remove(package)
-                if isinstance(change, str):
-                    req["packages"].add(change)
-
     # store request packages temporary in Redis and create a diff
     temp = str(uuid4())
     pipeline = r.pipeline(True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -475,22 +475,6 @@ def test_api_build_bad_packages(client):
     assert response.json.get("detail") == "Unsupported package(s): test4"
     assert response.status == "422 UNPROCESSABLE ENTITY"
 
-
-def test_api_build_package_to_remove_diff_packages_true(client, upstream):
-    response = client.post(
-        "/api/v1/build",
-        json=dict(
-            version="TESTVERSION",
-            target="testtarget/testsubtarget",
-            profile="testprofile",
-            packages=["test1", "test2", "package_to_remove"],
-            diff_packages=True,
-        ),
-    )
-    assert response.status == "200 OK"
-    assert response.json.get("request_hash") == "b7b991edc9a53302df840f842603288e"
-
-
 def test_api_build_package_to_remove_diff_packages_false(client, upstream):
     response = client.post(
         "/api/v1/build",
@@ -503,21 +487,6 @@ def test_api_build_package_to_remove_diff_packages_false(client, upstream):
         ),
     )
     assert response.status == "422 UNPROCESSABLE ENTITY"
-
-
-def test_api_build_package_to_replace(client, upstream):
-    response = client.post(
-        "/api/v1/build",
-        json=dict(
-            version="TESTVERSION",
-            target="testtarget/testsubtarget",
-            profile="testprofile",
-            packages=["test1", "test2", "package_to_replace"],
-            diff_packages=True,
-        ),
-    )
-    assert response.status == "200 OK"
-    assert response.json.get("request_hash") == "8dd81d51057d322b46aa3739ccf4a8a6"
 
 
 def test_api_build_cleanup(app, upstream):


### PR DESCRIPTION
This causes more issues than good. The server must only provide such information and the client should request the user what do to or may "auto default" to what `package_changes` suggest.

Changing this on the server side confuses clients that compare the requested list of packages with the resulting list of packages.

Signed-off-by: Paul Spooren <mail@aparcar.org>