### PR TITLE
branches: add revision and mandatory to changes

### DIFF
--- a/asu/branches.yml
+++ b/asu/branches.yml
@@ -22,8 +22,12 @@ branches:
       - 22.03.0-rc6
       - 22.03-SNAPSHOT
     package_changes:
-      kmod-nft-nat6:
-      firewall: firewall4
+      - source: kmod-nft-nat6
+        revision: 19160
+        mandatory: true
+      - source: firewall
+        target: firewall4
+        revision: 18611
 
   "21.02":
     enabled: true
@@ -67,5 +71,9 @@ branches:
     versions:
       - SNAPSHOT
     package_changes:
-      kmod-nft-nat6:
-      firewall: firewall4
+      - source: kmod-nft-nat6
+        revision: 20282
+        mandatory: true
+      - source: firewall
+        target: firewall4
+        revision: 18611


### PR DESCRIPTION
The revision can be used to "date" package changes so that updates between i.e. snapshots won't be suggested every time.

The mandatory field is used to specify if a changes is selectable or not. If a package is dropped, the changes will always be selected.

Signed-off-by: Paul Spooren <paul.spooren@rhebo.com>