### PR TITLE
misc: handle BRANCHES_FILE env variable and reload

### DIFF
--- a/asu/asu.py
+++ b/asu/asu.py
@@ -38,6 +38,7 @@ def create_app(test_config: dict = None) -> Flask:
         UPSTREAM_URL="https://downloads.openwrt.org",
         ALLOW_DEFAULTS=False,
         ASYNC_QUEUE=True,
+        BRANCHES_FILE=getenv("BRANCHES_FILE"),
     )
 
     if not test_config:
@@ -58,8 +59,8 @@ def create_app(test_config: dict = None) -> Flask:
             app.config[option] = Path(value)
             app.config[option].mkdir(parents=True, exist_ok=True)
 
-    if not "BRANCHES" in app.config:
-        if "BRANCHES_FILE" not in app.config:
+    if "BRANCHES" not in app.config:
+        if app.config["BRANCHES_FILE"] is None:
             app.config["BRANCHES_FILE"] = resource_filename(__name__, "branches.yml")
 
         with open(app.config["BRANCHES_FILE"], "r") as branches:

--- a/misc/asu.service
+++ b/misc/asu.service
@@ -6,8 +6,14 @@ After=network.target
 User=debian
 Group=debian
 WorkingDirectory=/home/debian/asu/
-Environment="PATH=/home/debian/.local/bin/"
-ExecStart=/home/debian/.local/bin/gunicorn --workers 3 --bind 127.0.0.1:8000 -m 007 "asu.asu:create_app()"
+Environment="BRANCHES_FILE=./branches.yml"
+ExecStart=/home/debian/.local/bin/gunicorn \
+    --bind 127.0.0.1:8000 \
+    --extra-reload-file "$BRANCHES_FILE" \
+    --reload \
+    --umask 007 \
+    --workers 3 \
+    "asu.asu:create_app()"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
if the BRANCHES_FILE is set i.e. via service file automatically reload gunicorn. This allows the modification of branches.yml without restarting the service manually.

Signed-off-by: Paul Spooren <paul.spooren@rhebo.com>