### PR TITLE
add branch-off-revision for each stable branch

### DIFF
--- a/asu/branches.yml
+++ b/asu/branches.yml
@@ -4,6 +4,7 @@ branches:
     extra_keys: []
     extra_repos: {}
     git_branch: openwrt-22.03
+    branch_off_rev: 19160
     name: "22.03"
     path: releases/{version}
     path_packages: releases/packages-{branch}
@@ -35,6 +36,7 @@ branches:
     extra_keys: []
     extra_repos: {}
     git_branch: openwrt-21.02
+    branch_off_rev: 15812
     name: "21.02"
     path: releases/{version}
     path_packages: releases/packages-{branch}


### PR DESCRIPTION
In order to be able which cross-branch package_changes to apply the clients needs to know at which point a stable branch has branched off the main/master branch.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>