### PR TITLE
api: add rootfs_size_mb parameter

### DIFF
--- a/asu/asu.py
+++ b/asu/asu.py
@@ -39,6 +39,7 @@ def create_app(test_config: dict = None) -> Flask:
         ALLOW_DEFAULTS=False,
         ASYNC_QUEUE=True,
         BRANCHES_FILE=getenv("BRANCHES_FILE"),
+        MAX_CUSTOM_ROOTFS_SIZE_MB=100,
     )
 
     if not test_config:
@@ -128,6 +129,12 @@ def create_app(test_config: dict = None) -> Flask:
         if not app.config["REDIS_CONN"].hexists("mapping-abi", package):
             app.config["REDIS_CONN"].hset("mapping-abi", package, source)
 
-    cnxn.add_api("openapi.yml", validate_responses=app.config["TESTING"])
+    cnxn.add_api(
+        "openapi.yml",
+        arguments={
+            "rootfs_size_mb_max": app.config["MAX_CUSTOM_ROOTFS_SIZE_MB"],
+        },
+        validate_responses=app.config["TESTING"],
+    )
 
     return app

--- a/asu/build.py
+++ b/asu/build.py
@@ -308,6 +308,8 @@ def build(req: dict):
         f"EXTRA_IMAGE_NAME={packages_hash}",
         f"BIN_DIR={req['store_path'] / bin_dir}",
     ]
+    if rootfs_size_mb := req.get("rootfs_size_mb"):
+        build_cmd.append(f"ROOTFS_PARTSIZE={rootfs_size_mb}")
 
     log.debug("Build command: %s", build_cmd)
 

--- a/asu/common.py
+++ b/asu/common.py
@@ -111,6 +111,7 @@ def get_request_hash(req: dict) -> str:
                 str(req.get("diff_packages", False)),
                 req.get("filesystem", ""),
                 get_str_hash(req.get("defaults", "")),
+                str(req.get("rootfs_size_mb", "")),
             ]
         ),
         32,

--- a/asu/openapi.yml
+++ b/asu/openapi.yml
@@ -265,6 +265,15 @@ components:
             Ability to specify filesystem running on device. Attaching this
             optional parameter will limit the ImageBuilder to only build
             firmware with that filesystem.
+        rootfs_size_mb:
+          type: integer
+          minimum: 1
+          maximum: {{ rootfs_size_mb_max }}
+          example: 100
+          description: |
+            Ability to specify a custom CONFIG_TARGET_ROOTFS_PARTSIZE for the
+            resulting image. Attaching this optional parameter will cause
+            ImageBuilder to build a rootfs with that size in MB.
         defaults:
           type: string
           description: |

--- a/misc/config.py
+++ b/misc/config.py
@@ -16,6 +16,9 @@ CACHE_PATH = None
 # where to store JSON files
 JSON_PATH = Path.cwd() / "public/json/v1/"
 
+# maximum custom rootfs size
+MAX_CUSTOM_ROOTFS_SIZE_MB = 100
+
 # manual mapping of package ABI changes
 MAPPING_ABI = {"libubus20191227": "libubus"}
 


### PR DESCRIPTION
The parameter allows the client to specify a custom value for
the CONFIG_TARGET_ROOTFS_PARTSIZE. This is especially useful
for the generic X86 images.

Fixes #415