### PR TITLE
fixed release_date in janitor.py

### DIFF
--- a/asu/janitor.py
+++ b/asu/janitor.py
@@ -419,11 +419,18 @@ def update_meta_json():
         json.dumps(
             current_app.config["OVERVIEW"],
             indent=2,
+            sort_keys=False,
+            default=str
         )
     )
 
     (current_app.config["JSON_PATH"] / "branches.json").write_text(
-        json.dumps(list(branches.values()))
+        json.dumps(
+            list(branches.values()),
+            indent=2,
+            sort_keys=False,
+            default=str
+        )
     )
 
     (current_app.config["JSON_PATH"] / "latest.json").write_text(


### PR DESCRIPTION
The janitor would fail if a branch node contained a date value. As a result, the branches.json, latest.json and overview.json files are never created and therefore acu and/or luci-app-attendedsysupgrade would not be able to update from the asu instance.

Converting json node values to string by default fixes the issue.

This fixes #427 

Signed-off-by: Marc Ahlgrim <marc@onemarcfifty.com>