### PR TITLE
api: allow to prefix packages with a +

### DIFF
--- a/asu/api.py
+++ b/asu/api.py
@@ -4,7 +4,7 @@ from flask import Blueprint, current_app, g, jsonify, redirect, request
 from rq import Connection, Queue
 
 from .build import build
-from .common import get_request_hash
+from .common import get_request_hash, remove_prefix
 
 bp = Blueprint("api", __name__, url_prefix="/api")
 
@@ -84,7 +84,7 @@ def validate_packages(req):
         else:
             tr.add(p)
 
-    req["packages"] = tr
+    req["packages"] = list(map(lambda x: remove_prefix(x, "+"), sorted(tr)))
 
     # store request packages temporary in Redis and create a diff
     temp = str(uuid4())

--- a/asu/common.py
+++ b/asu/common.py
@@ -174,3 +174,18 @@ def verify_usign(sig_file: Path, msg_file: Path, pub_key: str) -> bool:
         return True
     except nacl.exceptions.CryptoError:
         return False
+
+
+def remove_prefix(text, prefix):
+    """Remove prefix from text
+
+    TODO: remove once 3.8 is dropped
+
+    Args:
+        text (str): text to remove prefix from
+        prefix (str): prefix to remove
+
+    Returns:
+        str: text without prefix
+    """
+    return text[text.startswith(prefix) and len(prefix) :]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -68,3 +68,9 @@ def test_verify_usign():
     os.close(sig_fd)
     os.unlink(msg_path)
     os.unlink(sig_path)
+
+
+def test_remove_prefix():
+    assert remove_prefix("test", "test") == ""
+    assert remove_prefix("+test", "+") == "test"
+    assert remove_prefix("++test", "+") == "+test"


### PR DESCRIPTION
When adding a + to the beginning of a package name it will modify the order of packages and thereby fix dependency issues of OPKG.

This is more of a advanced user feature.