### PR TITLE
api: use generic images for armsr target

### DIFF
--- a/asu/api.py
+++ b/asu/api.py
@@ -132,7 +132,7 @@ def validate_request(req):
         r.hget(f"architecture:{req['branch']}", req["target"]) or b""
     ).decode()
 
-    if req["target"] in ["x86/64", "x86/generic", "x86/geode", "x86/legacy"]:
+    if req["target"] in ["x86/64", "x86/generic", "x86/geode", "x86/legacy", "armsr/armv7", "armsr/armv8"]:
         current_app.logger.debug("Use generic profile for {req['target']}")
         req["profile"] = "generic"
     else:


### PR DESCRIPTION
The new armsr (Arm SystemReady) target provides generic images for Arm platforms with EFI support.

These should be treated similarly to x86 in that the generic images should be used as a base, ignoring the board name.

See also: https://github.com/openwrt/luci/pull/6430