### PR TITLE
sign created images after build

### DIFF
--- a/asu/common.py
+++ b/asu/common.py
@@ -232,7 +232,16 @@ def diff_packages(requested_packages: set, default_packages: set):
     )
 
 
-def run_container(podman: PodmanClient, image, command, mounts=[], copy=[]):
+def run_container(
+    podman: PodmanClient,
+    image,
+    command,
+    mounts=[],
+    copy=[],
+    user=None,
+    environment={},
+    working_dir=None,
+):
     """Run a container and return the returncode, stdout and stderr
 
     Args:
@@ -250,10 +259,12 @@ def run_container(podman: PodmanClient, image, command, mounts=[], copy=[]):
         command=command,
         detach=True,
         mounts=mounts,
-        userns_mode="keep-id",
         cap_drop=["all"],
         no_new_privileges=True,
         privileged=False,
+        user=user,
+        working_dir=working_dir,
+        environment=environment,
     )
 
     returncode = container.wait()

--- a/asu/common.py
+++ b/asu/common.py
@@ -305,6 +305,7 @@ def run_container(
         logging.debug(f"Closed {host_tar}")
 
     container.remove(v=True)
+    podman.volumes.prune()  # TODO: remove once v=True works
 
     return returncode, stdout, stderr
 


### PR DESCRIPTION
Sign images in a separate container after the images is created. This prevents malicious installed packages to steal private keys with post-install scripts.