### PR TITLE
config: allow to modify operations timeout

### DIFF
--- a/asu/api.py
+++ b/asu/api.py
@@ -256,7 +256,7 @@ def api_v1_build_post():
             job_id=request_hash,
             result_ttl=result_ttl,
             failure_ttl=failure_ttl,
-            job_timeout="10m",
+            job_timeout=current_app.config["GLOBAL_TIMEOUT"] or "10m",
         )
     else:
         if job.is_finished:
@@ -344,7 +344,7 @@ def api_build_post():
             job_id=request_hash,
             result_ttl=result_ttl,
             failure_ttl=failure_ttl,
-            job_timeout="10m",
+            job_timeout=current_app.config["GLOBAL_TIMEOUT"] or "10m",
         )
 
     return return_job(job)

--- a/asu/asu.py
+++ b/asu/asu.py
@@ -37,6 +37,7 @@ def create_app(test_config: dict = None) -> Flask:
         BRANCHES_FILE=getenv("BRANCHES_FILE"),
         MAX_CUSTOM_ROOTFS_SIZE_MB=100,
         REPOSITORY_ALLOW_LIST=[],
+        GLOBAL_TIMEOUT=getenv("GLOBAL_TIMEOUT") or "10m"
     )
 
     if not test_config:
@@ -138,7 +139,7 @@ def create_app(test_config: dict = None) -> Flask:
                 "REPOSITORY_ALLOW_LIST": app.config["REPOSITORY_ALLOW_LIST"],
                 "REDIS_URL": app.config["REDIS_URL"],
             },
-            job_timeout="10m",
+            job_timeout=app.config["GLOBAL_TIMEOUT"],
         )
 
     return app

--- a/misc/config.py
+++ b/misc/config.py
@@ -44,3 +44,6 @@ REPOSITORY_ALLOW_LIST = [
 
 # where to downlaod the images from
 # UPSTREAM_PATH = "https://downloads.openwrt.org"
+
+# global operations timeout (used in downloading the requested imagebuilder and updating of profiles.json)
+# GLOBAL_TIMEOUT = "30m"


### PR DESCRIPTION
This introduces an additional option to modify the operations timeout (currently defaulted to '10m')

The reason is to allow an installation of asu even on a machine that has low bandwidth availability, or a fair amount of latency.
Under these conditions asu may work fine, however the installation process may timeout during the profiles.json update process (unless the amount of available branches/releases is reduced)
In addition, even a single build may timeout if more than 10 minutes are required between downloading the imagebuilder corresponding to a request and compiling it.