### PR TITLE
build: allow to define additional configs

### DIFF
--- a/asu/build_request.py
+++ b/asu/build_request.py
@@ -6,6 +6,9 @@ from asu.config import settings
 STRING_PATTERN = r"^[\w.,-]*$"
 TARGET_PATTERN = r"^[\w]*/[\w]*$"
 PKG_VERSION_PATTERN = r"^[\w.,~-]*$"
+CONFIG_PATTERN = (
+    r"^(# CONFIG_[\w_.-]+ is not set|CONFIG_[\w_.-]+=([\w_.-]+$|\"[^\"][\w_.-]+\"))$"
+)
 
 
 class BuildRequest(BaseModel):
@@ -158,3 +161,21 @@ class BuildRequest(BaseModel):
             """.strip(),
         ),
     ] = None
+    configs: Annotated[
+        list[Annotated[str, Field(pattern=CONFIG_PATTERN)]],
+        Field(
+            examples=[
+                [
+                    "CONFIG_VERSION_DIST=MyRouterOS",
+                    "CONFIG_VERSION_NUMBER=1.6",
+                    "CONFIG_TARGET_ROOTFS_TARGZ=y",
+                    "CONFIG_TARGET_ROOTFS_JFFS2=y",
+                    "# CONFIG_TARGET_ROOTFS_SQUASHFS is not set",
+                ]
+            ],
+            description="""
+                List of configs, only the few ones not related to kernel/packages 
+                as they will not be recompiled.
+            """.strip(),
+        ),
+    ] = []

--- a/asu/config.py
+++ b/asu/config.py
@@ -82,6 +82,14 @@ class Settings(BaseSettings):
     server_stats: str = "/stats"
     log_level: str = "INFO"
     squid_cache: bool = False
+    configs_allowed: list = []
+    # configs_allowed: list = [
+    #     'CONFIG_VERSION_DIST',
+    #     'CONFIG_VERSION_NUMBER',
+    #     'CONFIG_TARGET_ROOTFS_TARGZ',
+    #     'CONFIG_TARGET_ROOTFS_JFFS2',
+    #     'CONFIG_TARGET_ROOTFS_SQUASHFS'
+    # ]
 
 
 settings = Settings()

--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -17,6 +17,10 @@ from asu.util import (
     get_request_hash,
 )
 
+import re
+
+configs_extract = r"^# (CONFIG_[\w_.-]) is not set|(CONFIG_[\w_.-]+)"
+
 router = APIRouter()
 
 
@@ -70,6 +74,12 @@ def validate_request(build_request: BuildRequest) -> tuple[dict, int]:
 
     if build_request.distro not in get_distros():
         return validation_failure(f"Unsupported distro: {build_request.distro}")
+
+    if build_request.configs:
+        for config in build_request.configs:
+            config_key = re.search(configs_extract, config)
+            if config_key[0] not in settings.configs_allowed:
+                return validation_failure("Illegal config requested: {config_key[0]}")
 
     branch = get_branch(build_request.version)["name"]
 

--- a/asu/util.py
+++ b/asu/util.py
@@ -97,6 +97,18 @@ def get_file_hash(path: str) -> str:
     return h.hexdigest()
 
 
+def get_configs_hash(configs: list) -> str:
+    """Return sha256sum of configs list
+    Duplicate configs are automatically removed and the list is sorted to be
+    reproducible
+    Args:
+        configs (list): list of configs
+    Returns:
+        str: hash of `req`
+    """
+    return get_str_hash(" ".join(sorted(list(set(configs)))))
+
+
 def get_manifest_hash(manifest: dict[str, str]) -> str:
     """Return sha256sum of package manifest
 
@@ -132,6 +144,7 @@ def get_request_hash(build_request: BuildRequest) -> str:
                 build_request.target,
                 build_request.profile.replace(",", "_"),
                 get_packages_hash(build_request.packages),
+                get_configs_hash(build_request.configs),
                 get_manifest_hash(build_request.packages_versions),
                 str(build_request.diff_packages),
                 "",  # build_request.filesystem


### PR DESCRIPTION
This introduces the possibility of passing additional configs to the request.

Only the few not related to kernel/packages, as they are not recompiled by the imagebuilder, would make sense. 
For example, to request a specific name/number for a firmware image: 
```
CONFIG_VERSION_DIST=MyRouterOS
CONFIG_VERSION_NUMBER=1.6
```

Or to request a format other than the default format for the output firmware image, for example:
```
# CONFIG_TARGET_ROOTFS_SQUASHFS is not set
CONFIG_TARGET_ROOTFS_JFFS2=y
```