### PR TITLE
build: increase MAX_CUSTOM_ROOTFS_SIZE_MB to a reasonable value

### DIFF
--- a/asu/asu.py
+++ b/asu/asu.py
@@ -35,7 +35,7 @@ def create_app(test_config: dict = None) -> Flask:
         ALLOW_DEFAULTS=bool(getenv("ALLOW_DEFAULTS", False)),
         ASYNC_QUEUE=True,
         BRANCHES_FILE=getenv("BRANCHES_FILE"),
-        MAX_CUSTOM_ROOTFS_SIZE_MB=100,
+        MAX_CUSTOM_ROOTFS_SIZE_MB=1024,
         REPOSITORY_ALLOW_LIST=[],
         BASE_CONTAINER="ghcr.io/openwrt/imagebuilder",
     )

--- a/misc/config.py
+++ b/misc/config.py
@@ -14,7 +14,7 @@ STORE_PATH = Path.cwd() / "public/store/"
 JSON_PATH = Path.cwd() / "public/json/v1/"
 
 # maximum custom rootfs size
-MAX_CUSTOM_ROOTFS_SIZE_MB = 100
+MAX_CUSTOM_ROOTFS_SIZE_MB = 1024
 
 # manual mapping of package ABI changes
 MAPPING_ABI = {"libubus20191227": "libubus"}


### PR DESCRIPTION
Current value of 100 is less than default when building OpenWrt (104). Increase it to 1024 to allow large root file systems on devices that can accommodate them.

https://github.com/openwrt/openwrt/blob/61e8728d86d7c11e1a5adab4bd37dae6b3b6cf2b/config/Config-images.in#L306

Closes: https://github.com/openwrt/asu/issues/826