### PR TITLE
build: add missing image type

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -249,7 +249,7 @@ def build(req: dict, job=None):
             lambda i: i["name"],
             filter(
                 lambda i: i["type"]
-                in ["sysupgrade", "factory", "combined", "combined-efi"],
+                in ["sysupgrade", "factory", "combined", "combined-efi", "sdcard"],
                 json_content["profiles"][req["profile"]]["images"],
             ),
         )


### PR DESCRIPTION
Image type "sdcard" was missing from checks, so those images were not being signed.  Example platform is compulab_trimslice tegra/generic.

Snippet from build manifest, with ignored "type".
```
  "images": [
    {
      "filesystem": "squashfs",
      "name": "openwrt-415d38074a1b-tegra-generic-compulab_trimslice-squashfs-sdcard.img.gz",
      "sha256": "59ebfc597eb6e8fb1fb1b2bf781474fb7ee468ccad17b811d75f4d99c32e0100",
      "sha256_unsigned": "75543310f059f106c07d9691ab79b79021778488098b7c63b572ed85d0bb3c34",
      "type": "sdcard"
    },
```