### PR TITLE
config: add entry to package_changes

### DIFF
--- a/asu/branches.yml
+++ b/asu/branches.yml
@@ -90,6 +90,9 @@ branches:
     versions:
       - SNAPSHOT
     package_changes:
+      - source: auc
+        target: owut
+        revision: 26792
       - source: libustream-wolfssl
         target: libustream-mbedtls
         revision: 21994


### PR DESCRIPTION
'auc' has been removed and replaced by 'owut', reflect that in the 'package_changes'

https://github.com/openwrt/packages/commit/3a998e10218c318511b41739f276e572c1ede967

Signed-off-by: Eric Fahlgren <ericfahlgren@gmail.com>