### PR TITLE
routers/api: add constraints to API fields

### DIFF
--- a/asu/config.py
+++ b/asu/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     async_queue: bool = True
     branches_file: Union[str, Path, None] = None
     max_custom_rootfs_size_mb: int = 1024
+    max_defaults_length: int = 20480
     repository_allow_list: list = []
     base_container: str = "ghcr.io/openwrt/imagebuilder"
     update_token: Union[str, None] = "foobar"


### PR DESCRIPTION
Use pydantic's Field to add constraints to 'defaults' (string length <= 20480) and 'rootfs_size_mb' (int 1 <= value <= 1024) 'package_changes'

Reference:
https://docs.pydantic.dev/latest/concepts/fields/#numeric-constraints

Signed-off-by: Eric Fahlgren @efahl 