### PR TITLE
api: restore 'version_code' for auc and owut

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -65,11 +65,11 @@ def build(req: dict, job=None):
 
     version_code = re.search('Current Revision: "(r.+)"', job.meta["stdout"]).group(1)
 
-    if "version_code" in req:
-        if version_code != req.get("version_code"):
+    if requested := req.get("version_code"):
+        if version_code != requested:
             report_error(
                 job,
-                f"Received incorrect version {version_code} (requested {req['version_code']})",
+                f"Received incorrect version {version_code} (requested {requested})",
             )
 
     default_packages = set(

--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -16,6 +16,16 @@ router = APIRouter()
 class BuildRequest(BaseModel):
     distro: str = "openwrt"
     version: str
+    version_code: Annotated[
+        str,
+        Field(
+            default="",
+            description="It is possible to send the expected revision. "
+            "This allows to show the revision within clients before the "
+            "request. If the resulting firmware is a different revision, "
+            "the build results in an error.",
+        ),
+    ] = ""
     target: str
     packages: Optional[list] = []
     profile: str

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,7 +95,12 @@ def test_api_build_version_code_bad(client):
             packages=["test1", "test2"],
         ),
     )
-    assert response.status_code == 200
+    assert response.status_code == 500
+    data = response.json()
+    assert (
+        data["detail"]
+        == "Error: Received incorrect version r12647-cb44ab4f5d (requested some-bad-version-code)"
+    )
 
 
 def test_api_build_diff_packages(client):


### PR DESCRIPTION
Restore the 'version_code' field as it's used by both auc and owut to verify the resulting build.

Signed-off-by: Eric Fahlgren <ericfahlgren@gmail.com>
