### PR TITLE
build: retain user input order in package list

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -91,7 +91,7 @@ def build(req: dict, job=None):
 
     if req.get("diff_packages"):
         req["build_cmd_packages"] = diff_packages(
-            set(req["packages"]), default_packages | profile_packages
+            req["packages"], default_packages | profile_packages
         )
         log.debug(f"Diffed packages: {req['build_cmd_packages']}")
     else:
@@ -155,7 +155,7 @@ def build(req: dict, job=None):
             "make",
             "manifest",
             f"PROFILE={req['profile']}",
-            f"PACKAGES={' '.join(sorted(req.get('build_cmd_packages', [])))}",
+            f"PACKAGES={' '.join(req.get('build_cmd_packages', []))}",
             "STRIP_ABI=1",
         ],
         mounts=mounts,
@@ -180,7 +180,7 @@ def build(req: dict, job=None):
         "make",
         "image",
         f"PROFILE={req['profile']}",
-        f"PACKAGES={' '.join(sorted(req.get('build_cmd_packages', [])))}",
+        f"PACKAGES={' '.join(req.get('build_cmd_packages', []))}",
         f"EXTRA_IMAGE_NAME={packages_hash}",
         f"BIN_DIR=/builder/{bin_dir}",
     ]

--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -133,7 +133,7 @@ def validate_request(req):
     req["packages"] = list(
         map(
             lambda x: x.removeprefix("+"),
-            sorted(req.get("packages_versions", {}).keys() or req.get("packages", [])),
+            (req.get("packages_versions", {}).keys() or req.get("packages", [])),
         )
     )
 

--- a/asu/util.py
+++ b/asu/util.py
@@ -211,21 +211,19 @@ def get_podman():
     )
 
 
-def diff_packages(requested_packages: set, default_packages: set):
+def diff_packages(requested_packages: list, default_packages: set):
     """Return a list of packages to install and remove
 
     Args:
-        requested_packages (set): Set of requested packages
+        requested_packages (set): List of requested packages in user-specified order
         default_packages (set): Set of default packages
 
     Returns:
-        set: Set of packages to install and remove"""
-    remove_packages = default_packages - requested_packages
-    return list(
-        sorted(
-            requested_packages
-            | set(map(lambda p: f"-{p}".replace("--", "-"), remove_packages))
-        )
+        list: List of packages to install and remove"""
+    remove_packages = default_packages - set(requested_packages)
+    return (
+        sorted(set(map(lambda p: f"-{p}".replace("--", "-"), remove_packages)))
+        + requested_packages
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,12 +11,13 @@ def test_api_build(client):
             version="1.2.3",
             target="testtarget/testsubtarget",
             profile="testprofile",
-            packages=["test1", "test2"],
+            packages=["zzz", "test1", "qqq", "test2", "aaa"],
         ),
     )
     assert response.status_code == 200
     data = response.json()
     assert data["manifest"]["test1"] == "1.0"
+    assert data["build_cmd"][3] == "PACKAGES=zzz test1 qqq test2 aaa"
 
 
 def test_api_build_version_code(client):
@@ -110,7 +111,7 @@ def test_api_build_diff_packages(client):
             version="1.2.3",
             target="testtarget/testsubtarget",
             profile="testprofile",
-            packages=["test1", "test2"],
+            packages=["test1", "zzz", "test2", "aaa"],  # Order must be maintained.
             diff_packages=True,
         ),
     )
@@ -122,7 +123,13 @@ def test_api_build_diff_packages(client):
     # TODO shorten for testing
     assert (
         data["build_cmd"][3]
-        == "PACKAGES=-base-files -busybox -dnsmasq -dropbear -firewall -fstools -ip6tables -iptables -kmod-ath9k -kmod-gpio-button-hotplug -kmod-ipt-offload -kmod-usb-chipidea2 -kmod-usb-storage -kmod-usb2 -libc -libgcc -logd -mtd -netifd -odhcp6c -odhcpd-ipv6only -opkg -ppp -ppp-mod-pppoe -swconfig -uboot-envtools -uci -uclient-fetch -urandom-seed -urngd -wpad-basic test1 test2"
+        == "PACKAGES=-base-files -busybox -dnsmasq -dropbear -firewall -fstools"
+        " -ip6tables -iptables -kmod-ath9k -kmod-gpio-button-hotplug"
+        " -kmod-ipt-offload -kmod-usb-chipidea2 -kmod-usb-storage -kmod-usb2"
+        " -libc -libgcc -logd -mtd -netifd -odhcp6c -odhcpd-ipv6only -opkg"
+        " -ppp -ppp-mod-pppoe -swconfig -uboot-envtools -uci -uclient-fetch"
+        " -urandom-seed -urngd -wpad-basic"
+        " test1 zzz test2 aaa"
     )
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -49,14 +49,18 @@ def test_get_request_hash():
 
 
 def test_diff_packages():
-    assert diff_packages({"test1"}, {"test1", "test2"}) == ["-test2", "test1"]
-    assert diff_packages({"test1"}, {"test1"}) == ["test1"]
-    assert diff_packages({"test1"}, {"test2", "test3"}) == ["-test2", "-test3", "test1"]
-    assert diff_packages({"test1"}, {"test2", "-test3"}) == [
+    assert diff_packages(["test1"], {"test1", "test2"}) == ["-test2", "test1"]
+    assert diff_packages(["test1"], {"test1"}) == ["test1"]
+    assert diff_packages(["test1"], {"test2", "test3"}) == ["-test2", "-test3", "test1"]
+    assert diff_packages(["test1"], {"test2", "-test3"}) == [
         "-test2",
         "-test3",
         "test1",
     ]
+    assert diff_packages(["z", "x"], {"x", "y", "z"}) == ["-y", "z", "x"]
+    assert diff_packages(["x", "z"], {"x", "y", "z"}) == ["-y", "x", "z"]
+    assert diff_packages(["z", "y"], {"x", "y", "z"}) == ["-x", "z", "y"]
+    assert diff_packages(["y", "z"], {"x", "y", "z"}) == ["-x", "y", "z"]
 
 
 def test_fingerprint_pubkey_usign():


### PR DESCRIPTION
This allows users to work around an opkg bug that causes package installation failure when the package list is sorted.  For one specific example, see https://forum.openwrt.org/t/owut-openwrt-upgrade-tool/200035/61.

- Firmware selector needs to have its sort removed.
  https://github.com/openwrt/firmware-selector-openwrt-org/blob/master/www/index.js#L618
- I already updated owut. https://github.com/efahl/owut/commit/d8af324ccad0c93f0d6a9fd1e72236e55d480a7c
- Haven't looked at LuCI ASU yet.

Signed-off-by: Eric Fahlgren <ericfahlgren@gmail.com>