### PR TITLE
config: split 'upstream_url' to internal and external values

### DIFF
--- a/asu/config.py
+++ b/asu/config.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Union
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -10,7 +11,14 @@ class Settings(BaseSettings):
     public_path: Path = Path.cwd() / "public"
     json_path: Path = public_path / "json" / "v1"
     redis_url: str = "redis://localhost:6379"
-    upstream_url: str = "https://downloads.openwrt.org"
+    upstream_url: str = Field(
+        "https://mirror-03.infra.openwrt.org",
+        description="Upstream server for ASU internal use, must be as local as possible to ASU server.",
+    )
+    upstream_cdn: str = Field(
+        "https://downloads.openwrt.org",
+        description="Upstream server for client use, should be top-level name for CDN network.",
+    )
     allow_defaults: bool = False
     async_queue: bool = True
     branches_file: Union[str, Path, None] = None

--- a/asu/update.py
+++ b/asu/update.py
@@ -155,7 +155,7 @@ def update_meta_json():
     overview = {
         "latest": latest,
         "branches": branches,
-        "upstream_url": settings.upstream_url,
+        "upstream_url": settings.upstream_cdn,  # Client use only, see config.
         "server": {
             "version": __version__,
             "contact": "mail@aparcar.org",


### PR DESCRIPTION
Attempt to mitigate lag in CDN update which causes 'downloads' site to lag behind actual builds, and appears to propagate into the ASU server's metatdata.  We do this by splitting the 'upstream_url' into a "local" and "CDN" value, the former is used for all internal uses and the latter is reported to clients.

See https://github.com/openwrt/asu/issues/853#issuecomment-2265311030 for more detail.

Signed-off-by: Eric Fahlgren <ericfahlgren@gmail.com>