### PR TITLE
tests: fix deprecation warnings

### DIFF
--- a/tests/test_package_changes.py
+++ b/tests/test_package_changes.py
@@ -39,7 +39,7 @@ def test_apply_package_changes_does_not_modify_input_dict():
             "packages": ["kmod-ath9k-htc"],
         }
     )
-    original_req = build_request.copy()
+    original_req = build_request.model_copy()
     appy_package_changes(build_request)
 
     assert build_request == original_req
@@ -56,7 +56,7 @@ def test_apply_package_changes_release():
     )
     appy_package_changes(build_request)
 
-    original_build_request = build_request.copy()
+    original_build_request = build_request.model_copy()
     appy_package_changes(build_request)
 
     assert build_request == original_build_request


### PR DESCRIPTION
Use the new pydantic 'model_copy' method on BaseModel to eliminate deprecation warnings when running the tests.

(Picking away at some little stuff before I start submitting some bigger ones...)