### PR TITLE
asu: eliminate use of redis bytes data

### DIFF
--- a/asu/main.py
+++ b/asu/main.py
@@ -52,10 +52,10 @@ def index(request: Request):
             lambda b: (
                 b,
                 {
-                    "versions": list(redis_client.smembers(f"versions:{b}")),
+                    "versions": sorted(redis_client.smembers(f"versions:{b}")),
                 },
             ),
-            redis_client.smembers("branches"),
+            sorted(redis_client.smembers("branches")),
         )
     )
 

--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -31,9 +31,7 @@ def get_distros() -> list:
 @router.get("/revision/{version}/{target}/{subtarget}")
 def api_v1_revision(version: str, target: str, subtarget: str):
     return {
-        "revision": get_redis_client()
-        .get(f"revision:{version}:{target}/{subtarget}")
-        .decode("utf-8")
+        "revision": get_redis_client().get(f"revision:{version}:{target}/{subtarget}")
     }
 
 
@@ -127,7 +125,7 @@ def validate_request(build_request: BuildRequest):
             )
 
             if mapped_profile:
-                build_request.profile = mapped_profile.decode()
+                build_request.profile = mapped_profile
             else:
                 return (
                     {

--- a/asu/update.py
+++ b/asu/update.py
@@ -138,28 +138,20 @@ def update_meta_json():
     ]
 
     branches = dict(
-        map(
-            lambda b: (
-                b.decode(),
+        [
+            (
+                b,
                 {
-                    **get_branch(b.decode()),
-                    "name": b.decode(),
-                    "versions": list(
-                        map(
-                            lambda v: v.decode(),
-                            redis_client.smembers(f"versions:{b.decode()}"),
-                        )
-                    ),
+                    **get_branch(b),
+                    "name": b,
+                    "versions": sorted(redis_client.smembers(f"versions:{b}")),
                     "targets": dict(
-                        map(
-                            lambda a: (a[0].decode(), a[1].decode()),
-                            redis_client.hgetall(f"targets:{b.decode()}").items(),
-                        )
+                        sorted(redis_client.hgetall(f"targets:{b}").items())
                     ),
                 },
-            ),
-            redis_client.smembers("branches"),
-        )
+            )
+            for b in sorted(redis_client.smembers("branches"))
+        ]
     )
 
     overview = {

--- a/asu/util.py
+++ b/asu/util.py
@@ -19,8 +19,8 @@ from asu.build_request import BuildRequest
 from asu.config import settings
 
 
-def get_redis_client():
-    return redis.from_url(settings.redis_url, decode_responses=False)
+def get_redis_client(unicode=True):
+    return redis.from_url(settings.redis_url, decode_responses=unicode)
 
 
 def add_timestamp(key: str, labels: dict = {}):
@@ -39,7 +39,7 @@ def get_queue() -> Queue:
     Returns:
         Queue: The current RQ work queue
     """
-    return Queue(connection=get_redis_client(), is_async=settings.async_queue)
+    return Queue(connection=get_redis_client(False), is_async=settings.async_queue)
 
 
 def get_branch(version_or_branch: str) -> dict:


### PR DESCRIPTION
Let redis do the bytes to utf-8 conversions automatically, cleaning up the asu code.  Also fixes creation of overview.html template, which has been broken for a while.

- enable automatic decoding on creation of redis client
- remove all 'decode' calls on returned objects
- sort branch and version lists making comparisons when debugging easier