### PR TITLE
build: use exec_run with dmux

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1378,13 +1378,13 @@ files = [
 
 [[package]]
 name = "tzdata"
-version = "2024.1"
+version = "2024.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 files = [
-    {file = "tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"},
-    {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
+    {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},
+    {file = "tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"},
 ]
 
 [[package]]
@@ -1666,4 +1666,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "dd2f7a4c5b11c53b3b1b3fcbb3f851f6491382acfda06beb06eb64033fedd7aa"
+content-hash = "a010b512cd43125e2438276038216233289c586b75ac3526b7ffdc0e82e5288f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.11"
 fastapi = { extras = ["standard"], version = "^0.115.0" }
 pynacl = "^1.5.0"
 requests = "^2.32.3"
-podman = "^5.0.0"
+podman = "^5.1.0"
 redis = "^5.0.8"
 pydantic-settings = "^2.4.0"
 rq = "^1.16.2"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -16,7 +16,7 @@ from asu.util import (
     get_request_hash,
     get_str_hash,
     parse_packages_versions,
-    run_container,
+    run_cmd,
     verify_usign,
 )
 
@@ -141,13 +141,19 @@ def test_get_podman():
     assert isinstance(podman, PodmanClient)
 
 
-def test_run_container():
+def test_run_cmd():
     podman = get_podman()
     podman.images.pull("ghcr.io/openwrt/imagebuilder:testtarget-testsubtarget-v1.2.3")
 
-    returncode, stdout, stderr = run_container(
-        podman,
+    container = podman.containers.create(
         "ghcr.io/openwrt/imagebuilder:testtarget-testsubtarget-v1.2.3",
+        command=["sleep", "1000"],
+        detach=True,
+    )
+    container.start()
+
+    returncode, stdout, stderr = run_cmd(
+        container,
         ["make", "info"],
     )
 

--- a/tests/upstream/snapshots/targets/testtarget/testsubtarget/openwrt-imagebuilder-testtarget-testsubtarget.Linux-x86_64/Dockerfile
+++ b/tests/upstream/snapshots/targets/testtarget/testsubtarget/openwrt-imagebuilder-testtarget-testsubtarget.Linux-x86_64/Dockerfile
@@ -2,11 +2,10 @@ FROM alpine
 
 RUN apk add make bash
 
-RUN adduser -D builder -h /builder/
+RUN adduser -D buildbot -h /builder/
 
-USER builder 
+USER buildbot
 
 ADD ./ /builder/
 
 WORKDIR /builder/
-


### PR DESCRIPTION
Since upstream implemented `dmux` for exec_run it should be used instead of creating containers multiple times. Previously it wasn't possible to tell stderr apart from stdout, making it harder to parse things. Now with proper demuxing, recycle the container all three times, yey!