### PR TITLE
util: improve package file parsing

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -316,23 +316,18 @@ def check_manifest(manifest, packages_versions):
 
 def parse_packages_versions(text: str) -> dict:
     index = {}
-    linebuffer = ""
     architecure = ""
     parser = email.parser.Parser()
-    for line in text.splitlines():
-        if line == "":
-            package = parser.parsestr(linebuffer)
-            if not architecure:
-                architecure = package["Architecture"]
-            package_name = package["Package"]
-            if package_abi := package.get("ABIVersion"):
-                package_name = package_name.removesuffix(package_abi)
+    chunks = text.strip().split("\n\n")
+    for chunk in chunks:
+        package = parser.parsestr(chunk, headersonly=True)
+        if not architecure:
+            architecure = package["Architecture"]
+        package_name = package["Package"]
+        if package_abi := package.get("ABIVersion"):
+            package_name = package_name.removesuffix(package_abi)
 
-            index[package_name] = package["Version"]
-
-            linebuffer = ""
-        else:
-            linebuffer += line + "\n"
+        index[package_name] = package["Version"]
 
     return {"architecture": architecure, "packages": index}
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -114,11 +114,14 @@ def test_get_packages_versions():
         "Package: bort\n"
         "Version: 9.9.9\n"
         "\n"
+        "\n"  # Add two more to fake malformed input.
+        "\n"
     )
     index = parse_packages_versions(text)
     packages = index["packages"]
 
     assert index["architecture"] == "x86_64"
+    assert len(packages) == 3
     assert packages["libusb-1.0"] == "1.2.3"
     assert packages["libpython-3.3"] == "1.2.3"
     assert packages["bort"] == "9.9.9"


### PR DESCRIPTION
Occasionally, upstream package files are being terminated with extra newlines, resulting in '"null": null' entries in the resulting package index.  Strip the input text to avoid this.

Change the splitting method on the text to both reduce memory footprint and speed things up.

I reported this back in https://github.com/openwrt/asu/issues/866, but it was transient and I never got to the bottom of it.  Fixed now.