### PR TITLE
api: clean up handling of mapped_profiles

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ def redis_load_mock_data(redis):
     redis.sadd("packages:21.02:21.02.7:ath79/generic", "vim", "tmux")
     redis.sadd("packages:21.02:21.02.7:x86/64", "vim", "tmux")
 
+    redis.sadd("profiles:21.02:21.02.7:x86/64", "generic")
     redis.set("revision:21.02.7:x86/64", "r16847-f8282da11e")
 
     redis.hset(


### PR DESCRIPTION
Replace special casing for x86 and armsr with more algorithmic approach. Fixes bug with x86/geode, which was silently transforming 'geos' profile into 'generic'.  Handles other generic platforms without code changes.

Also did general cleanup/refactoring of build validation error handling, and added more build validation test cases.