### PR TITLE
build: pass in correct VERSION_PATH for release snapshots

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -68,6 +68,9 @@ def build(build_request: BuildRequest, job=None):
         environment.update(
             {
                 "TARGET": build_request.target,
+                "VERSION_PATH": "snapshots"
+                if build_request.version == "SNAPSHOT"
+                else f"releases/{build_request.version}",
                 "use_proxy": "on",
                 "http_proxy": "http://127.0.0.1:3128",
             }


### PR DESCRIPTION
Explicitly set the version path when creating the squid container so that we download the correct image builder for release snapshots.