### PR TITLE
git: ignore the squid cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ store/
 site/
 redis/
 public/
+squid/
 poetry.lock
 json/
 instance/


### PR DESCRIPTION
Once I started using squid, ruff was complaining about "read only" for all the cache dirs.