### PR TITLE
build: pass in correct VERSION_PATH for release snapshots

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -16,6 +16,7 @@ from asu.util import (
     check_manifest,
     diff_packages,
     fingerprint_pubkey_usign,
+    get_branch,
     get_container_version_tag,
     get_packages_hash,
     get_podman,
@@ -68,9 +69,9 @@ def build(build_request: BuildRequest, job=None):
         environment.update(
             {
                 "TARGET": build_request.target,
-                "VERSION_PATH": "snapshots"
-                if build_request.version.lower() == "snapshot"
-                else f"releases/{build_request.version}",
+                "VERSION_PATH": get_branch(build_request.version)
+                .get("path", "")
+                .replace("{version}", build_request.version),
                 "use_proxy": "on",
                 "http_proxy": "http://127.0.0.1:3128",
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,9 +95,9 @@ def app(redis_server, test_path, monkeypatch):
 
     settings.public_path = Path(test_path) / "public"
     settings.async_queue = False
-    settings.branches["1.2"] = {}
-    settings.branches["19.07"] = {}
-    settings.branches["21.02"] = {}
+    for branch in "1.2", "19.07", "21.02":
+        if branch not in settings.branches:
+            settings.branches[branch] = {"path": "releases/{version}"}
 
     monkeypatch.setattr("asu.util.get_redis_client", mocked_redis_client)
     monkeypatch.setattr("asu.routers.api.get_redis_client", mocked_redis_client)


### PR DESCRIPTION
A re-do to use the proper mechanism for determining actual upstream path, using upstream-provided data.

I had forgotten about this until I was fixing something in owut and saw the branches.path, "Oh, right!"