### PR TITLE
tests: add config to scan only tests directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ show_contexts   = "true"
 title           = "ASU Server Regression Test Coverage"
 
 
+[tool.pytest.ini_options]
+testpaths = [
+    "tests"
+]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Add a config entry to constrain pytest's search for test files and functions to only the 'tests/' directory.  This avoids error messages about read-only subdirectories, like you get when running squid.