### PR TITLE
builder: add more consistency and finer granularity to build status

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -286,8 +286,9 @@ def run_cmd(
 def report_error(job: Job, msg: str) -> None:
     logging.warning(f"Error: {msg}")
     job.meta["detail"] = f"Error: {msg}"
+    job.meta["imagebuilder_status"] = "failed"
     job.save_meta()
-    raise
+    raise RuntimeError(msg)
 
 
 def parse_manifest(manifest_content: str) -> dict[str, str]:


### PR DESCRIPTION
Ensure that 'imagebuilder_status' is reported at all phases of build, and add a final "done" status.

Ensure that all GET and HEAD requests to '/build' receive all x-headers regardless of build phase.

After reading through all the FastAPI docs, it turns out you can put '@get' and '@head' on the same function and it works just as you would expect.  Reduces code size a bit.

Extended the 'build_get' test to also include the HEAD request and confirm that sequential HEAD and GET requests receive the same data.