### PR TITLE
Overwrite FileResponse Content-Type with application/octet-stream for all files in /store

### DIFF
--- a/asu/fastapi/StaticFiles.py
+++ b/asu/fastapi/StaticFiles.py
@@ -1,0 +1,41 @@
+import os
+
+from fastapi.responses import FileResponse, Response
+from fastapi.staticfiles import StaticFiles as FastApiStaticFiles
+
+from starlette.staticfiles import PathLike
+from starlette.types import Scope
+
+class StaticFiles(FastApiStaticFiles):
+    def __init__(
+        self,
+        *,
+        directory: PathLike | None = None,
+        packages: list[str | tuple[str, str]] | None = None,
+        html: bool = False,
+        check_dir: bool = True,
+        follow_symlink: bool = False,
+    ) -> None:
+        super().__init__(
+            directory=directory, 
+            packages=packages, 
+            html=html, 
+            check_dir=check_dir, 
+            follow_symlink=follow_symlink
+        )
+    
+    def file_response(
+        self,
+        full_path: PathLike,
+        stat_result: os.stat_result,
+        scope: Scope,
+        status_code: int = 200,
+    ) -> Response:
+        response = super().file_response(
+            full_path, 
+            stat_result, 
+            scope, 
+            status_code)
+        if isinstance(response, FileResponse):
+            response.headers["Content-Type"] = "application/octet-stream"
+        return response;

--- a/asu/main.py
+++ b/asu/main.py
@@ -15,6 +15,7 @@ from asu import __version__
 from asu.config import settings
 from asu.routers import api
 from asu.util import get_redis_client, parse_feeds_conf, parse_packages_file
+from asu.fastapi.StaticFiles import StaticFiles as AsuStaticFiles
 
 logging.basicConfig(encoding="utf-8", level=settings.log_level)
 
@@ -36,7 +37,7 @@ app.include_router(api.router, prefix="/api/v1")
 (settings.public_path / "json").mkdir(parents=True, exist_ok=True)
 (settings.public_path / "store").mkdir(parents=True, exist_ok=True)
 
-app.mount("/store", StaticFiles(directory=settings.public_path / "store"), name="store")
+app.mount("/store", AsuStaticFiles(directory=settings.public_path / "store"), name="store")
 app.mount("/static", StaticFiles(directory=base_path / "static"), name="static")
 
 templates = Jinja2Templates(directory=base_path / "templates")


### PR DESCRIPTION
Fixes #1059 