### PR TITLE
config: refactor adding new releases

### DIFF
--- a/asu/config.py
+++ b/asu/config.py
@@ -3,6 +3,51 @@ from typing import Union
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+package_changes_list = [
+    {"source": "firewall", "target": "firewall4", "revision": 18611},
+    {"source": "kmod-nft-nat6", "revision": 20282, "mandatory": True},
+    {
+        "source": "libustream-wolfssl",
+        "target": "libustream-mbedtls",
+        "revision": 21994,
+    },
+    {"source": "px5g-wolfssl", "target": "px5g-mbedtls", "revision": 21994},
+    {
+        "source": "wpad-basic-wolfssl",
+        "target": "wpad-basic-mbedtls",
+        "revision": 21994,
+    },
+    {
+        "source": "libustream-wolfssl",
+        "target": "libustream-mbedtls",
+        "revision": 21994,
+    },
+    {"source": "auc", "target": "owut", "revision": 26792},
+    {
+        "source": "luci-app-opkg",
+        "target": "luci-app-package-manager",
+        "revision": 27897,
+    },
+]
+
+
+def package_changes(before=None):
+    changes = []
+    for change in package_changes_list:
+        if before is None or change["revision"] <= before:
+            changes.append(change)
+    return changes
+
+
+def release(branch_off_rev, enabled=True):
+    return {
+        "path": "releases/{version}",
+        "enabled": enabled,
+        "path_packages": "DEPRECATED",
+        "branch_off_rev": branch_off_rev,
+        "package_changes": package_changes(branch_off_rev),
+    }
+
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
@@ -26,74 +71,12 @@ class Settings(BaseSettings):
             "path": "snapshots",
             "enabled": True,
             "path_packages": "DEPRECATED",
-            "package_changes": [
-                {
-                    "source": "luci-app-opkg",
-                    "target": "luci-app-package-manager",
-                    "revision": 27897,
-                },
-                {"source": "auc", "target": "owut", "revision": 26792},
-                {
-                    "source": "libustream-wolfssl",
-                    "target": "libustream-mbedtls",
-                    "revision": 21994,
-                },
-                {"source": "px5g-wolfssl", "target": "px5g-mbedtls", "revision": 21994},
-                {
-                    "source": "wpad-basic-wolfssl",
-                    "target": "wpad-basic-mbedtls",
-                    "revision": 21994,
-                },
-                {
-                    "source": "libustream-wolfssl",
-                    "target": "libustream-mbedtls",
-                    "revision": 21994,
-                },
-                {"source": "kmod-nft-nat6", "revision": 20282, "mandatory": True},
-                {"source": "firewall", "target": "firewall4", "revision": 18611},
-            ],
+            "package_changes": package_changes(),
         },
-        "23.05": {
-            "path": "releases/{version}",
-            "enabled": True,
-            "path_packages": "DEPRECATED",
-            "branch_off_rev": 23069,
-            "package_changes": [
-                {
-                    "source": "libustream-wolfssl",
-                    "target": "libustream-mbedtls",
-                    "revision": 21994,
-                },
-                {"source": "px5g-wolfssl", "target": "px5g-mbedtls", "revision": 21994},
-                {
-                    "source": "wpad-basic-wolfssl",
-                    "target": "wpad-basic-mbedtls",
-                    "revision": 21994,
-                },
-                {
-                    "source": "libustream-wolfssl",
-                    "target": "libustream-mbedtls",
-                    "revision": 21994,
-                },
-                {"source": "kmod-nft-nat6", "revision": 19160, "mandatory": True},
-                {"source": "firewall", "target": "firewall4", "revision": 18611},
-            ],
-        },
-        "22.03": {
-            "path": "releases/{version}",
-            "enabled": True,
-            "path_packages": "DEPRECATED",
-            "branch_off_rev": 19160,
-            "package_changes": [
-                {"source": "kmod-nft-nat6", "revision": 19160, "mandatory": True},
-                {"source": "firewall", "target": "firewall4", "revision": 18611},
-            ],
-        },
-        "21.02": {
-            "path": "releases/{version}",
-            "enabled": True,
-            "path_packages": "DEPRECATED",
-        },
+        "24.10": release(27990),
+        "23.05": release(23069),
+        "22.03": release(19160),
+        "21.02": release(15812, enabled=True),  # Enabled for now...
     }
     server_stats: str = "/stats"
     log_level: str = "INFO"


### PR DESCRIPTION
Consolidate all the package changes into a single table. Factor all relevant release info into a single function.

Adds the 24.10 release and cleans up the addition of new releases, and new package changes.