### PR TITLE
config: enable use of new setup.sh in snapshots

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -66,7 +66,6 @@ def build(build_request: BuildRequest, job=None):
     image = f"{settings.base_container}:{build_request.target.replace('/', '-')}-{container_version_tag}"
 
     if settings.squid_cache and build_request.version.lower().endswith("snapshot"):
-        image = "localhost/imagebuilder:setup"
         environment.update(
             {
                 "TARGET": build_request.target,

--- a/asu/config.py
+++ b/asu/config.py
@@ -97,7 +97,7 @@ class Settings(BaseSettings):
     }
     server_stats: str = "/stats"
     log_level: str = "INFO"
-    squid_cache: bool = False
+    squid_cache: bool = True
 
 
 settings = Settings()


### PR DESCRIPTION
Run the setup.sh in the "new format" snapshot docker images prior to running any make commands.

@aparcar , probably need to do this soon as there are a lot of reports piling up on FS and elsewhere about "make info" not working, this is the fix.