### PR TITLE
util: read index.json for snapshot package feeds

### DIFF
--- a/asu/main.py
+++ b/asu/main.py
@@ -80,15 +80,11 @@ def json_v1_target_index(path: str):
 @app.get("/json/v1/{path:path}/{arch:path}-index.json")
 @cache(expire=600)
 def json_v1_arch_index(path: str, arch: str):
-    feeds = parse_feeds_conf(f"{settings.upstream_url}/{path}/{arch}")
-    packages = {}
+    feed_url: str = f"{settings.upstream_url}/{path}/{arch}"
+    feeds: list[str] = parse_feeds_conf(feed_url)
+    packages: dict[str, str] = {}
     for feed in feeds:
-        packages.update(
-            parse_packages_file(f"{settings.upstream_url}/{path}/{arch}/{feed}")[
-                "packages"
-            ]
-        )
-
+        packages.update(parse_packages_file(f"{feed_url}/{feed}").get("packages", {}))
     return packages
 
 

--- a/asu/util.py
+++ b/asu/util.py
@@ -328,7 +328,12 @@ def check_manifest(
 
 
 def parse_packages_file(url: str) -> dict[str, str]:
-    res: httpx.Response = httpx.get(f"{url}/Packages")
+    res: httpx.Response
+    if "/snapshots/" in url:
+        res = httpx.get(f"{url}/index.json")
+        return res.json() if res.status_code == 200 else {}
+
+    res = httpx.get(f"{url}/Packages")
     if res.status_code != 200:
         return {}
 


### PR DESCRIPTION
As of the apk switchover, the Packages file no longer is created as part of the package feeds.  Instead, utilize the index.json file created from apk's packages.db.

See https://github.com/openwrt/openwrt/commit/f841870