### PR TITLE
config: add the opkg -> apk-mbedtls package change

### DIFF
--- a/asu/config.py
+++ b/asu/config.py
@@ -28,6 +28,7 @@ package_changes_list = [
         "target": "luci-app-package-manager",
         "revision": 27897,
     },
+    {"source": "opkg", "target": "apk-mbedtls", "revision": 28056},
 ]
 
 


### PR DESCRIPTION
Allow 24.10 and earlier builds to transition their package manager transparently when they move to snapshots or post-24.10 releases.

Not a real high priority, but fixes a workaround in owut.  Probably makes life easier for LuCI app, too.  I waited for some clarity on how 24.10 was going to proceed, so this looks safe now.