### PR TITLE
build: use new imagebuilder setup.sh for appropriate versions

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -362,6 +362,11 @@ def parse_feeds_conf(url: str) -> list[str]:
     )
 
 
+def is_snapshot_build(version: str) -> bool:
+    """For imagebuilder containers using 'setup.sh' instead of fully populated."""
+    return version.lower().endswith("snapshot")
+
+
 def is_post_kmod_split_build(path: str) -> bool:
     """Root cause of what's going on here can be found at
     https://github.com/openwrt/buildbot/commit/a75ce026
@@ -381,7 +386,7 @@ def is_post_kmod_split_build(path: str) -> bool:
     if path.startswith("snapshots"):
         return True
 
-    version = path.split("/")[1]
+    version: str = path.split("/")[1]
     if version.startswith("24."):
         return True
     if version.startswith("23."):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -16,11 +16,12 @@ from asu.util import (
     get_podman,
     get_request_hash,
     get_str_hash,
-    is_post_kmod_split_build,
     parse_feeds_conf,
-    parse_kernel_version,
     parse_manifest,
     parse_packages_file,
+    parse_kernel_version,
+    is_post_kmod_split_build,
+    is_snapshot_build,
     run_cmd,
     verify_usign,
 )
@@ -193,6 +194,26 @@ def test_check_kmod_split():
 
     for path, expected in cases.items():
         result: bool = is_post_kmod_split_build(path)
+        assert result == expected
+
+
+def test_check_snapshot_versions():
+    cases = {
+        "22.07.3": False,
+        "23.05.0-rc3": False,
+        "23.05.2": False,
+        "23.05.5": False,
+        "23.05.6": False,
+        "23.05-SNAPSHOT": True,
+        "24.10.0-rc1": False,
+        "24.10.2": False,
+        "24.10-SNAPSHOT": True,
+        "SNAPSHOT": True,
+    }
+
+    for version, expected in cases.items():
+        result: bool = is_snapshot_build(version)
+        print(version, expected, result)
         assert result == expected
 
 


### PR DESCRIPTION
Properly detect versions for which the slim imagebuilder containers using setup.sh is being used.  Set up the container accordingly.

Allows building the new 24.10 versions, including the RCs.