### PR TITLE
ci: use correct context for docker build action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
           echo "__version__ = \"$TAG\"" > asu/__init__.py
           poetry version "$TAG"
 
-      - name: Build and publish
+      - name: Build and publish PyPi package
         if: github.event_name == 'release'
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
@@ -48,6 +48,7 @@ jobs:
             latest
 
       - name: Login to DockerHub
+        if: github.repository_owner == 'openwrt'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -56,7 +57,8 @@ jobs:
       - name: Build and push ASU to Docker Hub
         uses: docker/build-push-action@v5
         with:
+          context: .
           file: Containerfile
-          push: true
+          push: ${{ github.repository_owner == 'openwrt' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Instead of cloning the repository again, use the local context with the modified __version__.