### PR TITLE
build: don't crash if uci-defaults directory already exists

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -139,7 +139,7 @@ def build(build_request: BuildRequest, job=None):
         log.debug("Found defaults")
 
         defaults_file = bin_dir / "files/etc/uci-defaults/99-asu-defaults"
-        defaults_file.parent.mkdir(parents=True)
+        defaults_file.parent.mkdir(parents=True, exist_ok=True)
         defaults_file.write_text(build_request.defaults)
         mounts.append(
             {


### PR DESCRIPTION
When two builds are submitted for the same target/version and both include uci-defaults, then the second build fails with

   FileExistsError: [Errno 17] File exists: '.../files/etc/uci-defaults'

Links: https://forum.openwrt.org/t/owut-openwrt-upgrade-tool/200035/394