### PR TITLE
update: include any upcoming version in latest release list

### DIFF
--- a/asu/update.py
+++ b/asu/update.py
@@ -136,6 +136,8 @@ def update_meta_json():
         versions_upstream["stable_version"],
         versions_upstream["oldstable_version"],
     ]
+    if next_version := versions_upstream.get("upcoming_version"):
+        latest.append(next_version)
 
     branches = dict(
         [


### PR DESCRIPTION
The LuCI Attended Sysupgrade app uses the 'latest' list in overview.json to determine versions shown to the end user.  It currently does not show the 'upcoming_version', which means users don't see the 24.10.0-rc series.

If 'upcoming_version' exists, then let's add it to that list, so users can test out the RCs.

Fixes: https://github.com/openwrt/openwrt/issues/17595