### PR TITLE
feat: keep downloaded packages (releases only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ site/
 redis/
 public/
 squid/
+dl/
 poetry.lock
 json/
 instance/

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Now it's possible to run all services via `podman-compose`:
     echo "PUBLIC_PATH=$(pwd)/public" > .env
     # absolute path to podman socket mounted into worker containers
     echo "CONTAINER_SOCK=/run/user/$(id -u)/podman/podman.sock" >> .env
+    # (optional) keep a local copy of downloaded packages
+    echo "DL_PATH=$(pwd)/dl" >> .env
     podman-compose up -d
 
 This will start the server, the Podman API container and two workers. The first

--- a/asu/config.py
+++ b/asu/config.py
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     public_path: Path = Path.cwd() / "public"
+    dl_path: Path = Path.cwd() / "dl"
     redis_url: str = "redis://localhost:6379"
     upstream_url: str = "https://downloads.openwrt.org"
     allow_defaults: bool = False
@@ -71,6 +72,7 @@ class Settings(BaseSettings):
     server_stats: str = ""
     log_level: str = "INFO"
     squid_cache: bool = False
+    keep_downloaded_packages: bool = False
 
 
 settings = Settings()

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -34,6 +34,7 @@ services:
     command: rqworker --logging_level INFO
     env_file: asu.env
     volumes:
+      # - $DL_PATH:$DL_PATH:rw
       - $PUBLIC_PATH:$PUBLIC_PATH:rw
       - $CONTAINER_SOCK:$CONTAINER_SOCK:rw
     depends_on:


### PR DESCRIPTION
This increase the speed of subsequent builds for the same target (excluding snapshots),    
by saving a local copy of downloaded packages in a path defined as version/target/subtarget    
that is then mounted on the imagebuilder as a bind-volume,    
for example `/path/to/asu/dl/23.05.5/ath79/generic:/builder/dl` when building for ath79/generic.

Since this increase a few the storage needed, it is added as opt-in.     
In addition, to enable this also for snapshots, a mechanism to auto delete old/lower version_codes      
should be added, presumably linked to the `environment.update` part. [0]

This is the result of some tests made via the api at `http://0.0.0.0:8000/docs`
- with pre-pulled podman images 
- building twice for the same device, adding or removing packages among the default_packages, eg. opkg, vim, dnsmasq

Tested running the dev server, building for ath79-generic-8dev_carambola2
- the first build completes in 0:01:58.630602s
- the second build takes 0:01:26.964493s 

Tested with the podman-compose setup, building for ath79-nand-glinet_gl-xe300 [1]
- the first build completes in 0:01:55.503813s
- the second completes in 0:01:29.265000s


[0] Note: An alternative approach, would be to instruct apk (opkg)     
to use the local instance of squid if enabled      
for example adding this before the validate_manifest cmd `make manifest...`:
```
export http_proxy="http://10.89.0.1:3128"
sed -i 's|https|http|g' repositories
```
however in snapshots this apparently could not benefit of the squid cache without becoming error prone.

[1] Note: to complete the tests with podman I had to change these settings in `asu/config.py`,    
because it seems that `Path.cwd()` when is read inside the container erroneously points to    
`/app/dl/23.05.5/ath79/generic` instead of `/home/openwrt/asu/dl/23.05.5/ath79/generic`.     
Maybe I missed a better option to do the same changes:
```
# public_path: Path = Path.cwd() / "public"
public_path: Path = Path('/home/openwrt/asu/public/')
# dl_path: Path = Path.cwd() / "dl"
dl_path: Path = Path('/home/openwrt/asu/dl/')
