### PR TITLE
build: ensure request hash is the same as build hash

### DIFF
--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -233,6 +233,7 @@ def api_v1_build_post(
         job = get_queue().enqueue(
             build,
             build_request,
+            request_hash,
             job_id=request_hash,
             result_ttl=result_ttl,
             failure_ttl=failure_ttl,

--- a/asu/util.py
+++ b/asu/util.py
@@ -141,7 +141,12 @@ def get_request_hash(build_request: BuildRequest) -> str:
                 build_request.version_code,
                 build_request.target,
                 build_request.profile.replace(",", "_"),
-                get_packages_hash(build_request.packages),
+                get_packages_hash(
+                    x.removeprefix("+")
+                    for x in (
+                        build_request.packages_versions.keys() or build_request.packages
+                    )
+                ),
                 get_manifest_hash(build_request.packages_versions),
                 str(build_request.diff_packages),
                 "",  # build_request.filesystem


### PR DESCRIPTION
When using 'packages_versions' the request hash that is calculated before request validation in 'api_v1_build_post' often differs from the one calculated in 'build'.  This is due to 'validate_request' modifying the request's package lists.

We extract the request hash from the job, thus making them consistent again.