### PR TITLE
fix: replace `auc` with `owut` for 24.10 releases

### DIFF
--- a/asu/package_changes.py
+++ b/asu/package_changes.py
@@ -53,6 +53,12 @@ def apply_package_changes(build_request: BuildRequest):
             elif build_request.profile == "buffalo_wzr-hp-g300nh-rb":
                 _add_if_missing("kmod-switch-rtl8366rb")
 
+    if build_request.version.startswith("24.10"):
+        # `auc` no longer exists here
+        if "auc" in build_request.packages:
+            build_request.packages.remove("auc")
+            _add_if_missing("owut")
+
     # TODO: if we ever fully implement 'packages_versions', this needs rework
     for version, packages in language_packs.items():
         if build_request.version >= version:  # Includes snapshots


### PR DESCRIPTION
The cleaner implementation is to handle this on the clients. @efahl do you work on the LuCI app? If not we should consider dropping it or find someone else to maintain it.