### PR TITLE
build: apply-package-changes: handle long language identifiers

### DIFF
--- a/asu/package_changes.py
+++ b/asu/package_changes.py
@@ -65,5 +65,5 @@ def apply_package_changes(build_request: BuildRequest):
             for i, package in enumerate(build_request.packages):
                 for old, new in packages.items():
                     if package.startswith(old):
-                        lang = package.rsplit("-", 1)[1]
+                        lang = package.replace(old, "")
                         build_request.packages[i] = f"{new}{lang}"

--- a/tests/test_package_changes.py
+++ b/tests/test_package_changes.py
@@ -85,25 +85,29 @@ def test_apply_package_changes_lang_packs():
             "packages": [
                 "luci-i18n-opkg-ko",  # Should be replaced
                 "luci-i18n-xinetd-lt",  # Should be untouched
+                "luci-i18n-opkg-zh-cn",  # Should be replaced
             ],
         }
     )
 
-    assert len(build_request.packages) == 2
-    assert build_request.packages[0] == "luci-i18n-opkg-ko"
-    assert build_request.packages[1] == "luci-i18n-xinetd-lt"
-
-    apply_package_changes(build_request)
-
     assert len(build_request.packages) == 3
     assert build_request.packages[0] == "luci-i18n-opkg-ko"
     assert build_request.packages[1] == "luci-i18n-xinetd-lt"
-    assert build_request.packages[2] == "kmod-mt7622-firmware"
+    assert build_request.packages[2] == "luci-i18n-opkg-zh-cn"
+
+    apply_package_changes(build_request)
+
+    assert len(build_request.packages) == 4
+    assert build_request.packages[0] == "luci-i18n-opkg-ko"
+    assert build_request.packages[1] == "luci-i18n-xinetd-lt"
+    assert build_request.packages[2] == "luci-i18n-opkg-zh-cn"
+    assert build_request.packages[3] == "kmod-mt7622-firmware"
 
     build_request.version = "24.10.0-rc5"
     apply_package_changes(build_request)
 
-    assert len(build_request.packages) == 3
+    assert len(build_request.packages) == 4
     assert build_request.packages[0] == "luci-i18n-package-manager-ko"
     assert build_request.packages[1] == "luci-i18n-xinetd-lt"
-    assert build_request.packages[2] == "kmod-mt7622-firmware"
+    assert build_request.packages[2] == "luci-i18n-package-manager-zh-cn"
+    assert build_request.packages[3] == "kmod-mt7622-firmware"


### PR DESCRIPTION
Fix a bug in language packages name updates when the language identifier contains a dash.  Examples are "zn-ch" or "zh-hant".

Reported-by: @1715173329
Links: https://github.com/openwrt/asu/pull/1155#discussion_r1947690063