### PR TITLE
chore(ci): don't install libncurses5-dev anymore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install ImageBuilder prereqs
-        run: sudo apt-get install -y libncurses5-dev
-
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Things happen in containers these days