### PR TITLE
docs(self-hosted): document and simplify setup

### DIFF
--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -1,5 +1,9 @@
 name: Test podman-compose.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -31,8 +31,10 @@ jobs:
 
       - name: Start the containers
         run: |
-          podman system service --time=0 unix:///tmp/podman.sock &
-          cp misc/asu.env .env
+          export CONTAINER_SOCKET_PATH="/tmp/podman.sock"
+          podman system service --time=0 "unix://$CONTAINER_SOCKET_PATH" &
+          echo "PUBLIC_PATH=$(pwd)/public" > .env
+          echo "CONTAINER_SOCKET_PATH=$CONTAINER_SOCKET_PATH" >> .env
           podman-compose up -d
 
       - name: Let the containers start

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Test with pytest
         run: |
-          podman system service --time=0 unix:///tmp/podman.sock &
-          export CONTAINER_HOST="unix:///tmp/podman.sock"
+          export CONTAINER_SOCKET_PATH="/tmp/podman.sock"
+          podman system service --time=0 "unix://$CONTAINER_SOCKET_PATH" &
           poetry run coverage run -m pytest -vv --runslow
           poetry run coverage xml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Test Pull Request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/asu/config.py
+++ b/asu/config.py
@@ -53,7 +53,7 @@ class Settings(BaseSettings):
     max_defaults_length: int = 20480
     repository_allow_list: list = []
     base_container: str = "ghcr.io/openwrt/imagebuilder"
-    container_host: str = "localhost"
+    container_socket_path: str = ""
     container_identity: str = ""
     branches: dict = {
         "SNAPSHOT": {

--- a/asu/util.py
+++ b/asu/util.py
@@ -228,7 +228,7 @@ def get_container_version_tag(input_version: str) -> str:
 
 def get_podman() -> PodmanClient:
     return PodmanClient(
-        base_url=settings.container_host,
+        base_url=f"unix://{settings.container_socket_path}",
         identity=settings.container_identity,
     )
 

--- a/misc/asu.env
+++ b/misc/asu.env
@@ -1,7 +1,0 @@
-CONTAINER_HOST=unix:///tmp/podman.sock
-CONTAINER_SOCK=/tmp/podman.sock
-PUBLIC_PATH=/tmp/public/
-REDIS_URL=redis://redis/
-# SERVER_STATS=stats
-# SQUID_CACHE=1
-# ALLOW_DEFAULTS=1

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,9 +1,3 @@
-version: "2"
-
-volumes:
-  redis:
-  # grafana-storage:
-
 services:
   server:
     image: "docker.io/openwrt/asu:latest"
@@ -13,6 +7,8 @@ services:
     restart: unless-stopped
     command: uvicorn --host 0.0.0.0 asu.main:app
     env_file: .env
+    environment:
+      REDIS_URL: "redis://redis:6379/0"
     volumes:
       - $PUBLIC_PATH/store:$PUBLIC_PATH/store:ro
     ports:
@@ -28,31 +24,37 @@ services:
     restart: unless-stopped
     command: rqworker --logging_level INFO
     env_file: .env
+    environment:
+      REDIS_URL: "redis://redis:6379/0"
     volumes:
       - $PUBLIC_PATH:$PUBLIC_PATH:rw
-      - $CONTAINER_SOCK:$CONTAINER_SOCK:rw
+      - $CONTAINER_SOCKET_PATH:$CONTAINER_SOCKET_PATH:rw
     depends_on:
       - redis
-
-  # worker2:
-  #   image: "docker.io/openwrt/asu:latest"
-  #   restart: unless-stopped
-  #   command: rqworker --logging_level INFO
-  #   env_file: .env
-  #   volumes:
-  #     - $PUBLIC_PATH:$PUBLIC_PATH:rw
-  #     - $CONTAINER_SOCK:$CONTAINER_SOCK:rw
-  #   depends_on:
-  #     - redis
 
   redis:
     image: "docker.io/redis/redis-stack-server"
     restart: unless-stopped
     volumes:
-      - redis:/data/:rw
+      - ./redis-data:/data/:rw
     ports:
       - "127.0.0.1:6379:6379"
 
+  # Optionally add more workers
+  # worker2:
+  #   image: "docker.io/openwrt/asu:latest"
+  #   restart: unless-stopped
+  #   command: rqworker --logging_level INFO
+  #   env_file: .env
+  #   environment:
+  #    REDIS_URL: "redis://redis:6379/0"
+  #   volumes:
+  #     - $PUBLIC_PATH:$PUBLIC_PATH:rw
+  #     - $CONTAINER_SOCKET_PATH:$CONTAINER_SOCKET_PATH:rw
+  #   depends_on:
+  #     - redis
+  #
+  # Optionally add a Squid cache container when using `SQUID_CACHE`
   # squid:
   #   image: "docker.io/ubuntu/squid:latest"
   #   restart: unless-stopped
@@ -60,8 +62,9 @@ services:
   #     - "127.0.0.1:3128:3128"
   #   volumes:
   #     - ".squid.conf:/etc/squid/conf.d/snippet.conf:ro"
-  #     - "./squid/:/var/spool/squid/:rw"
+  #     - "./squid-data/:/var/spool/squid/:rw"
 
+  # Optionally add a Grafana container when using `SERVER_STATS`
   # grafana:
   #   image: docker.io/grafana/grafana-oss
   #   container_name: grafana
@@ -75,4 +78,4 @@ services:
   #     GF_SERVER_ROOT_URL: https://sysupgrade.openwrt.org/stats/
   #     GF_SERVER_SERVE_FROM_SUB_PATH: "true"
   #   volumes:
-  #     - grafana-storage:/var/lib/grafana
+  #     - ./grafana-data:/var/lib/grafana


### PR DESCRIPTION
Based on the work of @efahl with a bunch of simplifications.

* Drop `CONTAINER_SOCK` and `CONTAINER_HOST` in favour of `CONTAINER_SOCKET_PATH`.
* Install dependencies directly instead of using `pip`.
* Mention Podman socket via `systemd` or `podman service`
* Drop `asu.env`, there are no good defaults since variables are not evaluated, the Podman socket path varies etc.
* Drop outdated screenshot of `auc`.
* Some guidance on Squid cache setup.

Supersedes #1032