### PR TITLE
Fine-tune squid parameters

### DIFF
--- a/misc/squid.conf
+++ b/misc/squid.conf
@@ -1,11 +1,21 @@
 # Always revalidate cached content with the origin server
 refresh_pattern . 0 100% 0 refresh-ims
 
-# Allow caching of files up to 5GB
-maximum_object_size 5 GB
-
-# Set the cache size to 50GB
-cache_dir ufs /var/spool/squid 50000 16 256
-
 # Set memory cache size
 cache_mem 5 GB
+# Allow caching of objects up to 200 MB
+maximum_object_size 200 MB
+# Spool larger than usual objects to disk only
+maximum_object_size_in_memory 100 MB
+# While permit serving larger objects bypassing cache
+reply_body_max_size 500 MB
+# Optimizing file hit rate in memory
+memory_replacement_policy heap GSDF
+
+# Set the disk cache size to 50GB
+# This is default cache location on Debian/Ubuntu package
+# Where squid will use 25% more disk space at worst
+cache_dir ufs /var/spool/squid 50000 16 256
+# optimizing byte hit rate / network efficiency
+cache_replacement_policy heap LFUDA
+

--- a/misc/squid.conf
+++ b/misc/squid.conf
@@ -9,13 +9,14 @@ maximum_object_size 200 MB
 maximum_object_size_in_memory 100 MB
 # While permit serving larger objects bypassing cache
 reply_body_max_size 500 MB
+
 # Optimizing file hit rate in memory
 memory_replacement_policy heap GSDF
+# optimizing byte hit rate / network efficiency on disk
+cache_replacement_policy heap LFUDA
 
 # Set the disk cache size to 50GB
 # This is default cache location on Debian/Ubuntu package
 # Where squid will use 25% more disk space at worst
 cache_dir ufs /var/spool/squid 50000 16 256
-# optimizing byte hit rate / network efficiency
-cache_replacement_policy heap LFUDA
 


### PR DESCRIPTION
Mention most applicable parameters sizing squid cache

Tailored to 24.10.0 content Largest package 91MB, average 400KB median 120KB

Oversize packages of near future or full SDK will not affect memory cache efficiency by going directly to the disk

Can apply to current populated cache with -k reconfigure without restart

Signed-off-by: Andris PE <neandris@gmail.com>