### PR TITLE
feat: improvements in package caching

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -4,6 +4,8 @@ import hashlib
 import json
 import logging
 import struct
+from dateutil import parser
+from datetime import datetime
 from os import getgid, getuid
 from pathlib import Path
 from re import match
@@ -434,6 +436,19 @@ def parse_kernel_version(url: str) -> str:
     return ""
 
 
+def is_fully_compiled_version(version: str) -> bool:
+    """Check that a given version is at least 48h old"""
+    response = client_get(
+        settings.upstream_url + "/releases/" + version + "/.targets.json"
+    )
+
+    if response.extensions["from_cache"]:
+        last_modified = int(parser.parse(response.headers["Last-Modified"]).timestamp())
+        if int(datetime.now().timestamp()) - last_modified < 172800:
+            return False
+    return True
+
+
 def reload_versions(app: FastAPI) -> bool:
     response = client_get(settings.upstream_url + "/.versions.json")
 
@@ -450,6 +465,12 @@ def reload_versions(app: FastAPI) -> bool:
 
     if response.json()["upcoming_version"]:
         app.versions.append(response.json()["upcoming_version"])
+
+    # Avoid offering versions that are not yet fully compiled
+    for label in ["stable_version", "oldstable_version", "upcoming_version"]:
+        version = response.json()[label]
+        if version and not is_fully_compiled_version(version):
+            app.versions.remove(version)
 
     for branch in settings.branches.keys():
         if branch != "SNAPSHOT":

--- a/misc/squid.conf
+++ b/misc/squid.conf
@@ -1,6 +1,3 @@
-# Always revalidate cached content with the origin server
-refresh_pattern . 0 100% 0 refresh-ims
-
 # Allow caching of files up to 5GB
 maximum_object_size 5 GB
 
@@ -9,3 +6,15 @@ cache_dir ufs /var/spool/squid 50000 16 256
 
 # Set memory cache size
 cache_mem 5 GB
+
+# Prevent caching for one year uncompleted kernel modules during compilation (should be updated once a new release is published)
+refresh_pattern ^http://downloads.openwrt.org/releases/.*(23.05.[6-99]|24.10.[1-99]|25.*|SNAPSHOT)/targets/.* 0 100% 0 refresh-ims
+
+# Kernel modules for releases are compiled once, never expires: cache for a year
+refresh_pattern ^http://downloads.openwrt.org/releases/.*/targets/.* 525600 0% 525600 override-expire
+
+# Prevent revalidate cached content with the origin server for 30min (should exist a fallback to no_proxy)
+refresh_pattern ^http://downloads.openwrt.org/.*[^imagebuilder].* 30 0% 30 override-expire
+
+# Always revalidate cached content with the origin server
+refresh_pattern . 0 100% 0 refresh-ims

--- a/misc/squid.conf
+++ b/misc/squid.conf
@@ -7,14 +7,18 @@ cache_dir ufs /var/spool/squid 50000 16 256
 # Set memory cache size
 cache_mem 5 GB
 
-# Prevent caching for one year uncompleted kernel modules during compilation (should be updated once a new release is published)
-refresh_pattern ^http://downloads.openwrt.org/releases/.*(23.05.[6-99]|24.10.[1-99]|25.*|SNAPSHOT)/targets/.* 0 100% 0 refresh-ims
+# Consider replacing 'downloads.openwrt.org' with '.*openwrt.*' to include multiple mirrors
+# Always revalidate imagebuilders and sha256sums with the origin server
+refresh_pattern ^http://downloads.openwrt.org/releases/.*/targets/.*(imagebuilder|sha256sums).* 0 100% 0 refresh-ims
 
-# Kernel modules for releases are compiled once, never expires: cache for a year
-refresh_pattern ^http://downloads.openwrt.org/releases/.*/targets/.* 525600 0% 525600 override-expire
+# Always revalidate the content of snapshots with the origin server
+refresh_pattern -i ^http://downloads.openwrt.org/.*snapshot.* 0 100% 0 refresh-ims
 
-# Prevent revalidate cached content with the origin server for 30min (should exist a fallback to no_proxy)
-refresh_pattern ^http://downloads.openwrt.org/.*[^imagebuilder].* 30 0% 30 override-expire
+# Kernel modules for releases are compiled once, never expires: cache for one year
+refresh_pattern ^http://downloads.openwrt.org/releases/.*/targets/.* 525600 100% 525600 override-expire
+
+# Consider all the remaning packages as fresh for 30min (should exist a fallback to no_proxy)
+refresh_pattern ^http://downloads.openwrt.org/.* 30 100% 30 override-expire
 
 # Always revalidate cached content with the origin server
 refresh_pattern . 0 100% 0 refresh-ims


### PR DESCRIPTION
This adds some squid directives to consider fresh longer kernel modules of already compiled releases, to prevent revalidation against the origin server which consumes time.

An automatic mechanism to refresh the below squid directive should be included (e.g., 24h after the first appearance on https://downloads.openwrt.org/.versions.json)
```
refresh_pattern ^http://downloads.openwrt.org/releases/.*(23.05.[6-99]|24.10.[1-99]|25.*|SNAPSHOT)/targets/.* 0 100% 0 refresh-ims
```

This adds also a fallback to no_proxy (https) in case STDERR contains “package index are corrupt” to rule out cache problems and to allow packages to be considered fresh longer and thus not revalidated against the origin server
