### PR TITLE
Add default ttl to cache

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -32,9 +32,9 @@ def get_redis_client(unicode: bool = True) -> redis.client.Redis:
     return redis.from_url(settings.redis_url, decode_responses=unicode)
 
 
-def client_get(url: str) -> Response:
+def client_get(url: str, ttl: int = 3600) -> Response:
     return hishel.CacheClient(
-        storage=hishel.RedisStorage(client=get_redis_client(False)),
+        storage=hishel.RedisStorage(client=get_redis_client(False), ttl=ttl),
         controller=hishel.Controller(always_revalidate=True, allow_heuristics=True),
     ).get(url)
 


### PR DESCRIPTION
Set a default cache time of 1 hour so that the cache does not get stale. Calls to `client_get` can be modified as needed to have appropriate TTLs depending on the nature of the request.

Resolves #1327 