### PR TITLE
Changing publish action for multi arch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,8 +54,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push ASU to Docker Hub
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: Containerfile


### PR DESCRIPTION
This PR mainly aims to add support for Docker/Podman on arm64, currently [the latest tag](https://hub.docker.com/r/openwrt/asu/tags) only supports amd64.
Following the [README for build-push-action](https://github.com/docker/build-push-action?tab=readme-ov-file#usage) the change should straightforward by just adding two steps.