### PR TITLE
utils: eliminate cache races for .versions.json and profiles.json

### DIFF
--- a/asu/main.py
+++ b/asu/main.py
@@ -37,6 +37,7 @@ app.mount("/static", StaticFiles(directory=base_path / "static"), name="static")
 
 templates = Jinja2Templates(directory=base_path / "templates")
 
+app.latest = []
 app.versions = []
 reload_versions(app)
 logging.info(f"Found {len(app.versions)} versions")
@@ -104,17 +105,8 @@ def json_v1_profile(path: str, target: str, profile: str):
 
 
 def generate_latest():
-    response = client_get(f"{settings.upstream_url}/.versions.json")
-
-    versions_upstream = response.json()
-    latest = [
-        versions_upstream["stable_version"],
-        versions_upstream["oldstable_version"],
-    ]
-
-    if versions_upstream["upcoming_version"]:
-        latest.insert(0, versions_upstream["upcoming_version"])
-    return latest
+    reload_versions(app)  # Do a reload in case .versions.json has updated.
+    return app.latest
 
 
 @app.get("/json/v1/latest.json")


### PR DESCRIPTION
There were two code paths reading .versions.json, the first of which, in main:generate_latest, would update the cache version appropriately, but then when utils:reload_versions was called, it would see from_cache was true and never update its internal data structures.  The code paths were consolidated, so there is only one touch point for the .versions.json file now, eliminating the race.

Likewise, the version/target/profiles.json files are being read on many paths, but util:reload_profiles was basing its decision to update on the same flawed from_cache check.  Eliminating the cache check altogether seemed most appropriate here, as there's no easy way to consolidated the various uses of the profile.json file into a single point of contact.