### PR TITLE
build: put a limit on the number of queued build requests

### DIFF
--- a/asu/config.py
+++ b/asu/config.py
@@ -71,6 +71,7 @@ class Settings(BaseSettings):
     server_stats: str = ""
     log_level: str = "INFO"
     squid_cache: bool = False
+    max_pending_jobs: int = 200
 
 
 settings = Settings()

--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -230,6 +230,14 @@ def api_v1_build_post(
             response.status_code = status
             return content
 
+        job_queue_length = len(get_queue())
+        if job_queue_length > settings.max_pending_jobs:
+            return {
+                "status": 529,  # "Site is overloaded"
+                "title": "Server overloaded",
+                "detail": f"server overload, queue contains too many build requests: {job_queue_length}",
+            }
+
         job = get_queue().enqueue(
             build,
             build_request,


### PR DESCRIPTION
Restrict the number of build requests that may be in the queue by returning status=529 (server overloaded).

From observing the rate at which jobs are processed on the production server, it appears they are cleared at an average of just over 5 jobs/minute, so the selected queue length limit of 200 would equate to about a 40 minute wait.