### PR TITLE
util: handle None returned as output string

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -269,8 +269,8 @@ def run_cmd(
 ) -> tuple[int, str, str]:
     returncode, output = container.exec_run(command, demux=True, user="buildbot")
 
-    stdout: str = output[0].decode("utf-8")
-    stderr: str = output[1].decode("utf-8")
+    stdout: str = output[0].decode("utf-8") if output[0] else ""
+    stderr: str = output[1].decode("utf-8") if output[1] else ""
 
     log.debug(f"returncode: {returncode}")
     log.debug(f"stdout: {stdout}")


### PR DESCRIPTION
In newer python podman versions, the exec_run method may return None as a value for either of stdout or stderr when there is no output, where they previously always returned an empty bytestring. This raises an AttributeError when it occurs cascading into an "Internal server error", fix it by checking before decoding the bytestrings.


@aparcar:
This bug fix should be applied before doing any Python package upgrades on the production servers.