### PR TITLE
stats: accumulate results at same timestep

### DIFF
--- a/asu/routers/stats.py
+++ b/asu/routers/stats.py
@@ -23,7 +23,7 @@ def get_builds_per_hour():
         to_time=now,
         filters=["stats=builds"],
         with_labels=False,
-        aggregation_type="count",
+        aggregation_type="sum",
         bucket_size_msec=3600000,  # 1 hour
     )
 

--- a/asu/util.py
+++ b/asu/util.py
@@ -48,6 +48,7 @@ def add_timestamp(key: str, labels: dict[str, str] = {}, value: int = 1) -> None
         value=value,
         timestamp="*",
         labels=labels,
+        duplicate_policy="sum",
     )
 
 


### PR DESCRIPTION
When two build requests arrive at the same time (within one second of each other), adding the timestamp of the second request would fail and abort the build with the client seeing "500 Internal server error".

asu_server_1   File "/app/asu/routers/api.py", line 223, in api_v1_build_post
asu_server_1     add_timestamp(
asu_server_1   File "/app/asu/util.py", line 47, in add_timestamp
asu_server_1     get_redis_client().ts().add(
...
asu_server_1 redis.exceptions.ResponseError: TSDB: Error at upsert, update is not supported when DUPLICATE_POLICY is set to BLOCK mode

The timeseries "add" call has a default value of "block" for duplicate timestamps.  We change it to "sum", so that arbitrarily many requests can arrive at the same time without issue and we also accumulate proper statistics.