### PR TITLE
util: handle missing .versions.json gracefully

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -447,6 +447,9 @@ def reload_versions(app: FastAPI) -> bool:
     """
 
     response = client_get(settings.upstream_url + "/.versions.json")
+    if response.status_code != 200:
+        log.info(f".versions.json: failed to download {response.status_code}")
+        return False
 
     if response.extensions["from_cache"] and app.versions:
         return False


### PR DESCRIPTION
On rare occasion the download of .versions.json fails with a 404, probably due to requesting it while it's being updated.  If this happens during a build request, it causes an "Internal server error" and the job request fails.  Fix that by simply not updating the internal versions list and continuing on until the versions are available.