### PR TITLE
build: handle errors during container download

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -8,6 +8,7 @@ from typing import Union
 from time import perf_counter
 
 from rq import get_current_job
+from podman import errors
 
 from asu.build_request import BuildRequest
 from asu.config import settings
@@ -92,7 +93,10 @@ def build(build_request: BuildRequest, job=None):
     job.save_meta()
 
     log.info(f"Pulling {image}...")
-    podman.images.pull(image)
+    try:
+        podman.images.pull(image)
+    except errors.ImageNotFound:
+        report_error(job, f"Image not found: {image}")
     log.info(f"Pulling {image}... done")
 
     bin_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -137,6 +137,34 @@ def test_api_build_version_code_bad(client):
     )
 
 
+def test_build_missing_container():
+    from asu.build import build
+    from asu.build_request import BuildRequest
+
+    build_request = BuildRequest(
+        client="test/1.2.3",
+        target="lantiq/xrx200",
+        profile="bt_homehub-v5a",
+        version="24.10.1",
+    )
+
+    class fake_job:
+        meta = {}
+
+        def save_meta(self):
+            pass
+
+    try:
+        build(build_request, fake_job())
+    except Exception as exc:
+        assert (
+            str(exc)
+            == "Image not found: ghcr.io/openwrt/imagebuilder:lantiq-xrx200-v24.10.1"
+        )
+    else:
+        assert False, "No exception raised!"
+
+
 base_packages_diff = (
     "PACKAGES=-base-files -busybox -dnsmasq -dropbear -firewall -fstools"
     " -ip6tables -iptables -kmod-ath9k -kmod-gpio-button-hotplug"


### PR DESCRIPTION
If a container image is missing for whatever reason, then the image pull raises an exception:

 ImageNotFound: 404 Client Error: Not Found ({"message":"manifest unknown"}

This is propagated to the ASU clients as a "status 500 - Internal server error".  The ASU clients then simply report "init" as an error with no supporting details, leaving the user completely in the dark as to what is going on.

We add an error handler around the image pull, so now the server reports very specific details about the failure, helping diagnose the issue:

 RuntimeError: Image not found: ghcr.io/openwrt/imagebuilder:lantiq-xrx200-v24.10.1

Link: https://forum.openwrt.org/t/luci-attended-sysupgrade-support-thread/230552/68