### PR TITLE
api: expose internal server limits in overview

### DIFF
--- a/asu/main.py
+++ b/asu/main.py
@@ -58,6 +58,7 @@ def index(request: Request):
             version=__version__,
             server_stats=settings.server_stats,
             max_custom_rootfs_size_mb=settings.max_custom_rootfs_size_mb,
+            max_defaults_length=settings.max_defaults_length,
         ),
     )
 
@@ -154,6 +155,8 @@ def json_v1_overview():
             "contact": "mail@aparcar.org",
             "allow_defaults": settings.allow_defaults,
             "repository_allow_list": settings.repository_allow_list,
+            "max_custom_rootfs_size_mb": settings.max_custom_rootfs_size_mb,
+            "max_defaults_length": settings.max_defaults_length,
         },
     }
 

--- a/asu/templates/overview.html
+++ b/asu/templates/overview.html
@@ -83,6 +83,10 @@
 
                     <p>
                         <b>Allow custom UCI defaults:</b> {{ defaults }} <br />
+                        {% if defaults %}
+                        <b>Maximum UCI defaults script size:</b> {{
+                        max_defaults_length }} bytes <br />
+                        {% endif %}
                         <b>Maximum requested root filesystem size:</b> {{
                         max_custom_rootfs_size_mb }} MB <br />
                         <b>Available versions on this server:</b>


### PR DESCRIPTION
Add both the rootfs partition max size and uci-defaults scripts max length to the overview's server section, allowing clients to validate them prior to submitting an invalid request.  Display the uci-defaults size on the front page, if applicable.