### PR TITLE
util: handle missing .targets.json file

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -517,7 +517,7 @@ def reload_targets(app: FastAPI, version: str) -> bool:
     if response.extensions["from_cache"] and app.targets[version]:
         return False
 
-    app.targets[version] = response.json()
+    app.targets[version] = response.json() if response.status_code == 200 else {}
 
     return True
 


### PR DESCRIPTION
During the creation of a new maintenance release, it is possible that the new version's .target.json file has not yet been created. This causes a "500 internal server" error for all users, even if they request a different version.  Rather than crash attempting to decode the 404 html code as json, we simply return an empty dictionary.

This results in users seeing the "Unsupported target" message if they try to build the new version, but that's better than crashing for everyone.