### PR TITLE
util: sort rc versions properly

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -495,7 +495,8 @@ def reload_versions(app: FastAPI) -> bool:
     if "SNAPSHOT" in settings.branches.keys():
         app.versions.append("SNAPSHOT")
 
-    app.versions.sort(reverse=True)
+    # Create a key that puts -rcN between -SNAPSHOT and releases.
+    app.versions.sort(reverse=True, key=lambda v: v.replace(".0-rc", "-rc"))
 
     return True
 


### PR DESCRIPTION
Versions in the overview branches are intended to be sorted newest first (ignoring snapshot, which should always be last), but they were being sorted such that the release candidates were between the first stable release '.0' and the second stable '.1' release. The result looked like this:

    24.10.2
    24.10.1
    24.10.0-rc3
    24.10.0-rc2
    24.10.0-rc1
    24.10.0        <<< out of order
    24.10-SNAPSHOT

This causes the final release candidate to be interpreted as the newest, after the first stable release up until the stable '.1' release.

We now generate a sort key that moves all of the rc versions between the '-SNAPSHOT' and the '.0' release.