### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Upload Python Package and Docker Container
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openwrt/asu/security/code-scanning/3](https://github.com/openwrt/asu/security/code-scanning/3)

To fix this problem, you should add a minimal `permissions` block to the workflow, either at the root (applies to all jobs) or within the specific job (`deploy:`). The `contents: read` permission is the safest default minimum for most jobs. For jobs that perform deployments (such as building and publishing to PyPI, or pushing Docker images), you may need to add additional permissions if required by those actions. 

You should add the following block near the top of the workflow (after the `name:` and before or after the `on:` block), unless some steps require additional permissions (such as `packages: write`, `pull-requests: write`). Since this workflow publishes to PyPI and Docker, but does not appear to create releases or modify repository contents, starting with `contents: read` is appropriate. If in the future you discover you need more permissions for those actions, you may further specify (e.g. add `packages: write`).

Edit the `.github/workflows/publish.yml` file to add:

```yaml
permissions:
  contents: read
```

right after `name: ...`, before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
