### PR TITLE
build-request: sanitize profile before use

### DIFF
--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -211,6 +211,9 @@ def api_v1_build_post(
     request: Request,
     user_agent: str = Header(None),
 ):
+    # Sanitize the profile in case the client did not (bug in older LuCI app).
+    build_request.profile = build_request.profile.replace(",", "_")
+
     request_hash: str = get_request_hash(build_request)
     job: Job = get_queue().fetch_job(request_hash)
     status: int = 200

--- a/asu/util.py
+++ b/asu/util.py
@@ -141,7 +141,7 @@ def get_request_hash(build_request: BuildRequest) -> str:
                 build_request.version,
                 build_request.version_code,
                 build_request.target,
-                build_request.profile.replace(",", "_"),
+                build_request.profile,
                 get_packages_hash(
                     build_request.packages_versions.keys() or build_request.packages
                 ),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -529,7 +529,7 @@ def test_api_build_real_ath79(app):
             target="ath79/generic",
             version="23.05.5",
             packages=["tmux", "vim"],
-            profile="8dev_carambola2",
+            profile="8dev,carambola2",  # Test unsanitized profile.
         ),
     )
 


### PR DESCRIPTION
Older versions of the LuCI ASU app did not sanitize the device profile by replacing commas with underscores, it simply inserted the raw output from 'ubus call system board' into the request. This causes the build request to be rejected by the ASU server:

    Unsupported profile: sinovoip,bananapi-m2-berry. The requested
        profile was either dropped or never existed...

Let's make sure to sanitize profiles as soon as we receive them, to avoid this issue and ensure that all of our use is consistent with the upstream profile lists.

Link: https://forum.openwrt.org/t/luci-attended-sysupgrade-support-thread/230552/246