### PR TITLE
stats: rework summary statistics collection and display

### DIFF
--- a/asu/routers/stats.py
+++ b/asu/routers/stats.py
@@ -1,47 +1,60 @@
-from datetime import datetime
+from datetime import datetime as dt, timedelta, UTC
 
 from fastapi import APIRouter
 
-from asu.util import get_redis_client
+from asu.util import get_redis_ts
 
 router = APIRouter()
 
 
-def get_redis_ts():
-    return get_redis_client().ts()
+DAY_MS = 24 * 60 * 60 * 1000
+N_DAYS = 30
 
 
 @router.get("/builds-per-day")
-def get_builds_per_day():
-    ts = get_redis_ts()
-    now = int(datetime.utcnow().timestamp() * 1000)
-    start = now - 30 * 24 * 60 * 60 * 1000  # last 30 days
+def get_builds_per_day() -> dict:
+    """
+    References:
+    https://redis.readthedocs.io/en/latest/redismodules.html#redis.commands.timeseries.commands.TimeSeriesCommands.range
+    https://www.chartjs.org/docs/latest/charts/line.html
+    """
 
-    # aggregate all time series labeled with stats=builds
-    results = ts.mrange(
+    # "stop" is next midnight to define buckets on exact day boundaries.
+    stop = dt.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    stop += timedelta(days=1)
+    stop = int(stop.timestamp() * 1000)
+    start = stop - N_DAYS * DAY_MS
+
+    stamps = list(range(start, stop, DAY_MS))
+    labels = [str(dt.fromtimestamp(stamp // 1000, UTC))[:10] + "Z" for stamp in stamps]
+
+    ts = get_redis_ts()
+    rc = ts.client
+    range_options = dict(
         from_time=start,
-        to_time=now,
-        filters=["stats=builds"],
-        with_labels=False,
+        to_time=stop,
+        align=start,  # Ensures alignment of X values with "stamps".
         aggregation_type="sum",
-        bucket_size_msec=86400000,  # 1 day (24 hours)
+        bucket_size_msec=DAY_MS,
     )
 
-    # create a map from timestamp to build count
-    daily_counts = {}
-
-    for entry in results:
-        data = list(entry.values())[0][1]
-        for ts, value in data:
-            daily_counts[ts] = daily_counts.get(ts, 0) + int(value)
-
-    # sort by timestamp
-    sorted_data = sorted(daily_counts.items())
-
-    labels = [datetime.utcfromtimestamp(ts / 1000).isoformat() for ts, _ in sorted_data]
-    values = [count for _, count in sorted_data]
+    def get_dataset(event: str, color: str) -> dict:
+        """Fills "data" array completely, supplying 0 for missing values."""
+        key = f"stats:build:{event}"
+        result = ts.range(key, **range_options) if rc.exists(key) else []
+        data_map = dict(result)
+        return {
+            "label": event.title(),
+            "data": [data_map.get(stamp, 0) for stamp in stamps],
+            "color": color,
+        }
 
     return {
         "labels": labels,
-        "datasets": [{"label": "Builds per day", "data": values}],
+        "datasets": [
+            # See add_build_event for valid "event" values.
+            get_dataset("requests", "green"),
+            get_dataset("cache-hits", "orange"),
+            get_dataset("failures", "red"),
+        ],
     }

--- a/asu/templates/overview.html
+++ b/asu/templates/overview.html
@@ -116,24 +116,22 @@
                         labels: data.labels,
                         datasets: data.datasets.map(ds => ({
                             data: ds.data,
+                            label: ds.label,
+                            backgroundColor: ds.color,
+                            borderColor: ds.color,
+                            borderJoinStyle: "round",
                             fill: false
                         }))
                     },
                     options: {
                         responsive: true,
                         scales: {
-                          x: {
-                            display: false
-                          },
-                          y: {
-                            display: true
-                          }
+                            x: { display: false },
+                            y: { display: true }
                         },
                         plugins: {
-                          legend: {
-                            display: false
-                          },
-                            title: { display: false }
+                            legend: { display: true },
+                            title:  { display: false }
                         }
                     }
                 });

--- a/misc/stats_modernize.py
+++ b/misc/stats_modernize.py
@@ -1,0 +1,47 @@
+from asu.util import get_redis_ts
+
+stat_types = (
+    "cache-hits",
+    "cache-misses",
+    "failures",
+    "requests",
+    "successes",
+)
+
+ts = get_redis_ts()
+rc = ts.client
+
+converted = rc.exists("stats:build:requests")
+force = False
+if converted and not force:
+    print("Already converted =====================")
+else:
+    print("Converting ============================")
+
+    if rc.exists("stats:cache-misses"):
+        # Note: "rename" overwrites any existing destination...
+        rc.rename("stats:cache-misses", "stats:build:cache-misses")
+    if rc.exists("stats:cache-hits"):
+        # Old stats are completely incorrect, so just delete them.
+        rc.delete("stats:cache-hits")
+
+    for stat_type in stat_types:
+        key = f"stats:build:{stat_type}"
+        func = ts.alter if rc.exists(key) else ts.create
+        func(key, labels={"stats": "summary"}, duplicate_policy="sum")
+
+    # Attempt to repopulate total requests and success values as
+    # accurately as possible using existing stats:builds:* data.
+    ts.delete("stats:build:requests", "-", "+")  # Empty them out.
+    ts.delete("stats:build:successes", "-", "+")
+    all_builds = ts.mrange("-", "+", filters=["stats=builds"])
+    for build in all_builds:
+        _, data = build.popitem()
+        series = data[1]
+        for stamp, value in series:
+            ts.add("stats:build:requests", timestamp=stamp, value=value)
+            ts.add("stats:build:successes", timestamp=stamp, value=value)
+
+    for stat_type in stat_types:
+        key = f"stats:build:{stat_type}"
+        print(f"{key:<25} - {ts.info(key).total_samples} samples")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -157,6 +157,14 @@ def test_build_missing_container():
     try:
         build(build_request, fake_job())
     except Exception as exc:
+        chain = exc
+        while hasattr(chain, "__context__") and chain.__context__:
+            # We want the original exception, not anything that FakeRedis
+            # generated during processing of it.
+            chain = chain.__context__
+            if isinstance(chain, RuntimeError):
+                exc = chain
+                break
         assert str(exc).startswith(
             "Image not found: ghcr.io/openwrt/imagebuilder:lantiq-xrx200-v24.10.1"
         )


### PR DESCRIPTION
The front page graph of "Builds per Day" is too minimal for any meaningful use.  Let's rework it to show per-day numbers for:

- total build requests
- total failures
- count of requests satisfied by already-built images

Many internal enhancements were made and some bugs were fixed.

- Centralize the mechanism for logging summary build events.
- The old cache-hits value was completely incorrect, being logged for every download and hence was grossly over reporting.
- Rework the aggregation bucket boundaries to land on midnight, so that the "per day" values really are per day.
- Add lines to graph as mentioned above.
- Add a test for the 'builds-per-day' API call.
- Extend the summary stats test to verify all data.

Since the old summary data format is no longer used, a conversion script is provided with this commit.  See misc/stats_modernize.py, which is intended to be run once before this upgraded code is deployed (although it is safe to run multiple times, its only destructive act is to delete the invalid 'cache-hits').

Link: https://github.com/openwrt/asu/discussions/1513