### PR TITLE
build-request: sanitize incoming "supported devices" list

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -534,7 +534,7 @@ def reload_profiles(app: FastAPI, version: str, target: str) -> bool:
     )
 
     app.profiles[version][target] = {
-        name: profile
+        name.replace(",", "_"): profile
         for profile, data in response.json()["profiles"].items()
         for name in data.get("supported_devices", []) + [profile]
     }


### PR DESCRIPTION
Commit 2e9edfd62ed5b079348b1e27c8f19024603d0420 created a bug when using LuCI ASU app, where device profiles that should be translated via the "Supported Devices" list are not being handled.  Root cause was testing only using owut, which does the translation prior to submitting the request, thus bypassing this code path.

Fix it by sanitizing the names coming from upstream profiles.json.