### PR TITLE
build: eliminate kill of already stopped containers

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -298,11 +298,9 @@ def _build(build_request: BuildRequest, job=None):
     job.save_meta()
 
     if any(err in job.meta["stderr"] for err in ["is too big", "out of space?"]):
-        container.kill()
         report_error(job, "Selected packages exceed device storage")
 
     if returncode:
-        container.kill()
         report_error(job, "Error while building firmware. See stdout/stderr")
 
     json_file = bin_dir / "profiles.json"


### PR DESCRIPTION
Some error paths result in the container.kill being called twice. This results in an erroneous error report to the user, with the podman error superseding the actual build error in the message output:

    409 Client Error: Conflict (can only kill running containers...

Fix it by removing the extra calls.