### PR TITLE
profiles: improve SUPPORTED_DEVICES handling and profile identification

### DIFF
--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -220,9 +220,6 @@ def api_v1_build_post(
     request: Request,
     user_agent: str = Header(None),
 ):
-    # Sanitize the profile in case the client did not (bug in older LuCI app).
-    build_request.profile = build_request.profile.replace(",", "_")
-
     add_build_event("requests")
 
     request_hash: str = get_request_hash(build_request)

--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -19,6 +19,7 @@ from asu.util import (
     reload_profiles,
     reload_targets,
     reload_versions,
+    resolve_profile,
 )
 
 router = APIRouter()
@@ -127,61 +128,16 @@ def validate_request(
                 "try again later."
             )
 
-    def valid_profile(profile: str, build_request: BuildRequest) -> bool:
-        profiles = app.profiles[build_request.version][build_request.target]
-        if profile in profiles:
-            return True
-        else:
-            for supported_devices in profiles.values():
-                if profile in supported_devices:
-                    return True
-
-        if len(profiles) == 1 and "generic" in profiles:
-            # Handles the x86, armsr and other generic variants.
-            build_request.profile = "generic"
-            return True
-        return False
-
-    if not valid_profile(build_request.profile, build_request):
-        reload_profiles(app, build_request.version, build_request.target)
-        if not valid_profile(build_request.profile, build_request):
-            return validation_failure(
-                f"Unsupported profile: {build_request.profile}. The requested "
-                "profile was either dropped or never existed. Please check the "
-                "forums for more information."
-            )
-
-    # Translate DTS compatible strings to actual profile names:
-    # *Only firmware-selector client is suppose to send the profile directly,
-    # *translate if it is not an already translated profile
     if build_request.profile not in app.profiles[build_request.version][build_request.target]:
-        first_occurrence = 0
-        profiles_appearances: dict[str, int] = dict()
-        for profile, supported_devices in app.profiles[build_request.version][build_request.target].items():
-            if build_request.profile in supported_devices:
-                profiles_appearances[profile] = supported_devices.index(build_request.profile)
-                
-        if len(profiles_appearances) == 1:
-            build_request.profile = profiles_appearances[0]
-        else:
-            # If there are multiple profiles including the requested DTS compatible string,
-            # select the one where it is the first in the list of SUPPORTED_DEVICES
-            logging.info(
-                f"DTS Compatible string: {build_request.profile} appears in "
-                f"multiple profiles, included in: {profiles_appearances}"
-            )
-            for profile, index in profiles_appearances.items():
-                if index == 0:
-                    first_occurrence += 1
-                    build_request.profile = profile
-            if first_occurrence != 1:
-                return validation_failure(
-                    f"Identification profile problem: {build_request.profile}. "
-                     "The requested DTS compatible string has more than one "
-                     "profile including it as the first SUPPORTED_DEVICES. "
-                     "Or it is not the first in the list for any profile. "
-                    f"{profiles_appearances} Please check the forums for more information."
-                )
+        reload_profiles(app, build_request.version, build_request.target)
+
+    try:
+        build_request.profile = resolve_profile(
+            app.profiles[build_request.version][build_request.target],
+            build_request.profile,
+        )
+    except ValueError as e:
+        return validation_failure(str(e))
 
     return ({}, None)
 

--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -212,6 +212,11 @@ def api_v1_build_post(
 ):
     add_build_event("requests")
 
+    content, status = validate_request(request.app, build_request)
+    if content:
+        response.status_code = status
+        return content
+
     request_hash: str = get_request_hash(build_request)
     job: Job = get_queue().fetch_job(request_hash)
     status: int = 200
@@ -237,11 +242,6 @@ def api_v1_build_post(
 
     if job is None:
         add_build_event("cache-misses")
-
-        content, status = validate_request(request.app, build_request)
-        if content:
-            response.status_code = status
-            return content
 
         job_queue_length = len(get_queue())
         if job_queue_length > settings.max_pending_jobs:

--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -131,6 +131,11 @@ def validate_request(
         profiles = app.profiles[build_request.version][build_request.target]
         if profile in profiles:
             return True
+        else:
+            for supported_devices in profiles.values():
+                if profile in supported_devices:
+                    return True
+
         if len(profiles) == 1 and "generic" in profiles:
             # Handles the x86, armsr and other generic variants.
             build_request.profile = "generic"
@@ -146,9 +151,38 @@ def validate_request(
                 "forums for more information."
             )
 
-    build_request.profile = app.profiles[build_request.version][build_request.target][
-        build_request.profile
-    ]
+    # Translate DTS compatible strings to actual profile names:
+    # *Only firmware-selector client is suppose to send the profile directly,
+    # *translate if it is not an already translated profile
+    if build_request.profile not in app.profiles[build_request.version][build_request.target]:
+        first_occurrence = 0
+        profiles_appearances: dict[str, int] = dict()
+        for profile, supported_devices in app.profiles[build_request.version][build_request.target].items():
+            if build_request.profile in supported_devices:
+                profiles_appearances[profile] = supported_devices.index(build_request.profile)
+                
+        if len(profiles_appearances) == 1:
+            build_request.profile = profiles_appearances[0]
+        else:
+            # If there are multiple profiles including the requested DTS compatible string,
+            # select the one where it is the first in the list of SUPPORTED_DEVICES
+            logging.info(
+                f"DTS Compatible string: {build_request.profile} appears in "
+                f"multiple profiles, included in: {profiles_appearances}"
+            )
+            for profile, index in profiles_appearances.items():
+                if index == 0:
+                    first_occurrence += 1
+                    build_request.profile = profile
+            if first_occurrence != 1:
+                return validation_failure(
+                    f"Identification profile problem: {build_request.profile}. "
+                     "The requested DTS compatible string has more than one "
+                     "profile including it as the first SUPPORTED_DEVICES. "
+                     "Or it is not the first in the list for any profile. "
+                    f"{profiles_appearances} Please check the forums for more information."
+                )
+
     return ({}, None)
 
 

--- a/asu/util.py
+++ b/asu/util.py
@@ -654,9 +654,8 @@ def reload_profiles(app: FastAPI, version: str, target: str) -> bool:
     )
 
     app.profiles[version][target] = {
-        name: profile
+        profile: data.get("supported_devices", [])
         for profile, data in response.json()["profiles"].items()
-        for name in data.get("supported_devices", []) + [profile]
     }
 
     return True

--- a/asu/util.py
+++ b/asu/util.py
@@ -661,6 +661,57 @@ def reload_profiles(app: FastAPI, version: str, target: str) -> bool:
     return True
 
 
+def resolve_profile(
+    profiles: dict[str, list[str]],
+    board_name: str,
+) -> str:
+    """Resolve a board identifier (DTS compatible or profile name) to a
+    canonical profile name.
+
+    Args:
+        profiles: Mapping of profile name -> list of supported device strings
+        board_name: The string sent by the client
+
+    Returns:
+        The canonical profile name string.
+
+    Raises:
+        ValueError: If resolution fails (ambiguous or not found)
+    """
+    if board_name in profiles:
+        return board_name
+
+    candidates: dict[str, int] = {}
+    for name, supported in profiles.items():
+        if board_name in supported:
+            candidates[name] = supported.index(board_name)
+
+    if not candidates:
+        # Handles the x86, armsr and other generic variants.
+        if len(profiles) == 1 and "generic" in profiles:
+            return "generic"
+        raise ValueError(
+            f"Unsupported profile: {board_name}. The requested "
+            "profile was either dropped or never existed. Please check "
+            "the forums for more information."
+        )
+
+    if len(candidates) == 1:
+        return next(iter(candidates))
+
+    firsts = {name: idx for name, idx in candidates.items() if idx == 0}
+    if len(firsts) == 1:
+        return next(iter(firsts))
+
+    raise ValueError(
+        f"Identification profile problem: {board_name}. "
+        "The requested DTS compatible string has more than one "
+        "profile including it as the first SUPPORTED_DEVICES. "
+        "Or it is not the first in the list for any profile. "
+        f"{candidates} Please check the forums for more information."
+    )
+
+
 class ErrorLog:
     """Redis-backed error log for build failures.
 

--- a/asu/util.py
+++ b/asu/util.py
@@ -169,7 +169,7 @@ def get_request_hash(build_request: BuildRequest) -> str:
                 build_request.version,
                 build_request.version_code,
                 build_request.target,
-                build_request.profile,
+                build_request.profile.replace(",", "_"),
                 get_packages_hash(
                     build_request.packages_versions.keys() or build_request.packages
                 ),

--- a/asu/util.py
+++ b/asu/util.py
@@ -654,7 +654,7 @@ def reload_profiles(app: FastAPI, version: str, target: str) -> bool:
     )
 
     app.profiles[version][target] = {
-        name.replace(",", "_"): profile
+        name: profile
         for profile, data in response.json()["profiles"].items()
         for name in data.get("supported_devices", []) + [profile]
     }

--- a/asu/util.py
+++ b/asu/util.py
@@ -169,7 +169,7 @@ def get_request_hash(build_request: BuildRequest) -> str:
                 build_request.version,
                 build_request.version_code,
                 build_request.target,
-                build_request.profile.replace(",", "_"),
+                build_request.profile,
                 get_packages_hash(
                     build_request.packages_versions.keys() or build_request.packages
                 ),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -573,7 +573,7 @@ def test_api_build_real_ath79(app):
             target="ath79/generic",
             version="25.12.2",
             packages=["tmux", "vim"],
-            profile="8dev,carambola2",  # Test unsanitized profile.
+            profile="8dev_carambola2",
         ),
     )
 


### PR DESCRIPTION
The actual handling does not allow to several devices share a DTS compatible string to allow image compatibility between them.

- Take the lists as lists and select the profile after checking all possible candidates.

- Throw a new validation exception when it is not possible to identify a profile which will help to identify inconsistencies.

This also can help to make a little bit clearer the difference between "profile" and "DTS compatible string".

*There is not need to add [profile] to SUPPORTED_DEVICES list anymore. https://github.com/openwrt/asu/blob/03287041d39a7cd59b87721642e3d84a948f1825/asu/util.py#L566

Reasoning about the reverts: https://github.com/openwrt/asu/pull/1511#issuecomment-3587079528 I would like to add that those commits would make harder to understand how we are handling the translation from Device Tree compatible strings to actual profiles names. 

 Before: [^1]
```
'glinet,gl-mt2500': 'glinet_gl-mt2500-airoha',                    <-- Entries are overwritten translating, wrongly to airoha variant
'glinet,mt2500-emmc': 'glinet_gl-mt2500-airoha',
'glinet,gl-mt2500-airoha': 'glinet_gl-mt2500-airoha',
'glinet_gl-mt2500': 'glinet_gl-mt2500',
'glinet_gl-mt2500-airoha': 'glinet_gl-mt2500-airoha'
```

 After:
 ```
'glinet_gl-mt2500': ['glinet,gl-mt2500', 'glinet,mt2500-emmc', 'glinet,gl-mt2500-airoha', 'glinet_gl-mt2500'],
 'glinet_gl-mt2500-airoha': ['glinet,gl-mt2500-airoha', 'glinet,mt2500-emmc', 'glinet,gl-mt2500', 'glinet_gl-mt2500-airoha'],
```
With this structure, select the profile where the board_name appear first in the list if the entry is shared.

 [^1]: https://github.com/openwrt/asu/issues/1525#issuecomment-3497242570

 Fixes: https://github.com/openwrt/asu/issues/1525
 Fixes: https://github.com/openwrt/openwrt/issues/20566
 
 ---------------------------
 V2:
- Extracted profile resolution into a standalone `resolve_profile()` function that handles DTS compatible → canonical profile name resolution with explicit ambiguity detection, replacing the inline `valid_profile()` helper.
- Fixed a cache consistency issue: the request hash was computed from the raw board_name before profile resolution. The comma-to-underscore sanitization in `get_request_hash()` handled the case where board_name equals profile_name after sanitization, but not aliases resolved via the supported_devices list or the x86/armsr/... generic fallback — those produced different cache keys than the canonical profile, defeating caching.

Resolution behavior comparison (profile → list format vs flat dict):
```
Profiles data (profile: SUPPORTED_DEVICES list):
  engenius_esr1200:         ["engenius,esr1200", "esr1200", "esr1750", "engenius,esr1750"]
  engenius_esr1750:         ["engenius,esr1750", "esr1750", "esr1200", "engenius,esr1200"]
  ubnt_unifi-ap:            ["ubnt,unifi-ap", "unifi", "ubnt,unifi"]
  ubnt_unifi-ap-lr:         ["ubnt,unifi-ap-lr", "unifi", "ubnt,unifi", "ubnt,unifi-ap"]
```
  
| Input | Flat raw | Flat sanitized | List format |
|---|---|---|---:|
| engenius_esr1200 | engenius_esr1200 ✅ | engenius_esr1750 ❌ | engenius_esr1200 ✅ |
| engenius,esr1200 | engenius_esr1750 ❌ | engenius_esr1750 ❌ | engenius_esr1200 ✅ |
| esr1200 | engenius_esr1750 ❌ | engenius_esr1750 ❌ | error ✅ |
| esr1750 | engenius_esr1750 ❌ | engenius_esr1750 ❌ | error ✅ |
| engenius,esr1750 | engenius_esr1750 ✅ | engenius_esr1750 ✅ | engenius_esr1750 ✅ |
| engenius_esr1750 | engenius_esr1750 ✅ | engenius_esr1750 ✅ | engenius_esr1750 ✅ |

| Input | Flat raw | Flat sanitized | List format |
|---|---|---|---:|
| ubnt_unifi-ap | ubnt_unifi-ap ✅ | ubnt_unifi-ap-lr ❌ | ubnt_unifi-ap ✅ |
| ubnt,unifi-ap | ubnt_unifi-ap-lr ❌ | ubnt_unifi-ap-lr ❌ | ubnt_unifi-ap ✅ |
| unifi | ubnt_unifi-ap-lr ❌ | ubnt_unifi-ap-lr ❌ | error ✅ |
| ubnt,unifi | ubnt_unifi-ap-lr ❌ | ubnt_unifi-ap-lr ❌ | error ✅ |
| ubnt_unifi-ap-lr | ubnt_unifi-ap-lr ✅ | ubnt_unifi-ap-lr ✅ | ubnt_unifi-ap-lr ✅ |
| ubnt,unifi-ap-lr | ubnt_unifi-ap-lr ✅ | ubnt_unifi-ap-lr ✅ | ubnt_unifi-ap-lr ✅ |