### PR TITLE
build: add job timeout setting

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -8,6 +8,7 @@ from typing import Union
 from time import perf_counter
 
 from rq import get_current_job
+from rq.utils import parse_timeout
 from podman import errors
 
 from asu.build_request import BuildRequest
@@ -169,7 +170,7 @@ def _build(build_request: BuildRequest, job=None):
 
     container = podman.containers.create(
         image,
-        command=["sleep", "600"],
+        command=["sleep", str(parse_timeout(settings.job_timeout))],
         mounts=mounts,
         cap_drop=["all"],
         no_new_privileges=True,

--- a/asu/config.py
+++ b/asu/config.py
@@ -96,6 +96,7 @@ class Settings(BaseSettings):
     build_defaults_ttl: str = "30m"
     build_failure_ttl: str = "10m"
     max_pending_jobs: int = 200
+    job_timeout: str = "10m"
 
 
 settings = Settings()

--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -257,7 +257,7 @@ def api_v1_build_post(
             job_id=request_hash,
             result_ttl=result_ttl,
             failure_ttl=failure_ttl,
-            job_timeout="10m",
+            job_timeout=settings.job_timeout,
         )
     else:
         if job.is_finished:


### PR DESCRIPTION
Allows changing the job timeout from the default of 10 minutes to any required value in hours, minutes or seconds (e.g. '1h', '3m', '5s').

This allows an increased timeout for systems that can't complete a build in 10 minutes.