### PR TITLE
config: add support for 25.12

### DIFF
--- a/asu/config.py
+++ b/asu/config.py
@@ -83,6 +83,7 @@ class Settings(BaseSettings):
             "path_packages": "DEPRECATED",
             "package_changes": package_changes(),
         },
+        "25.12": release(32295),
         "24.10": release(27990),
         "23.05": release(23069),
         "22.03": release(19160),


### PR DESCRIPTION
Add 25.12 support for package_changes, using openwrt/openwrt@12316d028 as the revision.

 $ scripts/getver.sh 12316d028
 r32295+1-c25265953b9c