### PR TITLE
stats: add a builds-by-branch chart to show trends

### DIFF
--- a/asu/routers/stats.py
+++ b/asu/routers/stats.py
@@ -11,6 +11,21 @@ DAY_MS = 24 * 60 * 60 * 1000
 N_DAYS = 30
 
 
+def start_stop(duration, interval):
+    """Calculate the time series boundaries and bucket values."""
+
+    # "stop" is next midnight to define buckets on exact day boundaries.
+    stop = dt.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    stop += timedelta(days=1)
+    stop = int(stop.timestamp() * 1000)
+    start = stop - duration * interval
+
+    stamps = list(range(start, stop, interval))
+    labels = [str(dt.fromtimestamp(stamp // 1000, UTC))[:10] + "Z" for stamp in stamps]
+
+    return start, stop, stamps, labels
+
+
 @router.get("/builds-per-day")
 def get_builds_per_day() -> dict:
     """
@@ -19,14 +34,7 @@ def get_builds_per_day() -> dict:
     https://www.chartjs.org/docs/latest/charts/line.html
     """
 
-    # "stop" is next midnight to define buckets on exact day boundaries.
-    stop = dt.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
-    stop += timedelta(days=1)
-    stop = int(stop.timestamp() * 1000)
-    start = stop - N_DAYS * DAY_MS
-
-    stamps = list(range(start, stop, DAY_MS))
-    labels = [str(dt.fromtimestamp(stamp // 1000, UTC))[:10] + "Z" for stamp in stamps]
+    start, stop, stamps, labels = start_stop(N_DAYS, DAY_MS)
 
     ts = get_redis_ts()
     rc = ts.client
@@ -56,5 +64,59 @@ def get_builds_per_day() -> dict:
             get_dataset("requests", "green"),
             get_dataset("cache-hits", "orange"),
             get_dataset("failures", "red"),
+        ],
+    }
+
+
+@router.get("/builds-by-version")
+def get_builds_by_version(branch: str = None) -> dict():
+    """If 'branch' is None, then data will be returned "by branch",
+    so you get one curve for each of 23.05, 24.10, 25.12 etc.
+
+    If you specify a branch, say "24.10", then the results are for
+    all versions on that branch, 24.10.0, 24.1.1 and so on."""
+
+    interval = 7 * DAY_MS  # Each bucket is a week.
+    duration = 26  # Number of weeks of data, about 6 months.
+
+    start, stop, stamps, labels = start_stop(duration, interval)
+
+    bucket = {}
+
+    def sum_data(version, data):
+        data_map = dict(data)
+        if version not in bucket:
+            bucket[version] = [0.0] * len(stamps)
+        for i, stamp in enumerate(stamps):
+            bucket[version][i] += data_map.get(stamp, 0)
+
+    range_options = dict(
+        filters=["stats=builds"],
+        with_labels=True,
+        from_time=start,
+        to_time=stop,
+        align=start,  # Ensures alignment of X values with "stamps".
+        aggregation_type="sum",
+        bucket_size_msec=interval,
+    )
+
+    result = get_redis_ts().mrange(**range_options)
+    for row in result:
+        for data in row.values():
+            version = data[0]["version"]
+            if branch and not version.startswith(branch):
+                continue
+            elif branch is None and "." in version:
+                version = version[:5]
+            sum_data(version, data[1])
+
+    return {
+        "labels": labels,
+        "datasets": [
+            {
+                "label": version,
+                "data": bucket[version],
+            }
+            for version in sorted(bucket)
         ],
     }

--- a/asu/templates/overview.html
+++ b/asu/templates/overview.html
@@ -76,6 +76,10 @@
                         <h2>Builds per Day (last 30 days)</h2>
                         <canvas id="buildsChart" width="600" height="300"></canvas>
                     </div>
+                    <div class="grid-item">
+                        <h2>Weekly build counts by branch (last 6 months)</h2>
+                        <canvas id="versionChart" width="600" height="300"></canvas>
+                    </div>
                     {% endif %}
 
                     <details>
@@ -106,11 +110,11 @@
 {% if server_stats %}
         <script src="static/chart.js"></script>
         <script>
-            async function loadBuildStats() {
-                const response = await fetch("/api/v1/builds-per-day");
+            async function loadChart(chartSource, canvas) {
+                const response = await fetch(`/api/v1/${chartSource}`);
                 const data = await response.json();
 
-                const countChart = new Chart(document.getElementById("buildsChart"), {
+                const countChart = new Chart(document.getElementById(canvas), {
                     type: "line",
                     data: {
                         labels: data.labels,
@@ -137,7 +141,14 @@
                 });
             }
 
-            loadBuildStats()
+            loadChart("builds-per-day", "buildsChart");
+            loadChart("builds-by-version", "versionChart");
+
+            /* We could add a dropdown with branch values, then show the
+               per-version values just for that branch like this:
+
+               loadChart("builds-by-version?branch=24.10", "versionChart");
+            */
         </script>
 {% endif %}
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -150,3 +150,18 @@ def test_stats_builds_per_day(client, redis_server: FakeStrictRedis):
     assert "datasets" in data
     assert "data" in data["datasets"][0]
     assert len(data["datasets"][0]["data"]) == N_DAYS
+
+
+def test_stats_builds_by_version(client, redis_server: FakeStrictRedis):
+    response = client.post("/api/v1/build", json=build_config_1)
+    response = client.post("/api/v1/build", json=build_config_2)
+
+    response = client.get("/api/v1/builds-by-version")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "labels" in data
+    assert len(data["labels"]) == 26
+    assert "datasets" in data
+    assert len(data["datasets"]) == 1
+    assert len(data["datasets"][0]["data"]) == 26


### PR DESCRIPTION
Show a time series plot of builds by branch.  After playing with various values, I decided upon a 7-day bucket and a 6-month total interval, which gives a long enough period to get a good feel for trends without being too dense and confusing.

I also aggregated the data for all versions within a branch by default (so, 24.10.* all appear as just "24.10"), but the API call has a "branch" parameter, which allows you to show just the versions within a given branch.  I did not expose this in the UI, let's make sure this works first.

---

@aparcar 
Is this what you were thinking?

Here's what it looks like running against the minimal historical data on my test server:

<img width="983" height="1133" alt="image" src="https://github.com/user-attachments/assets/03958f7b-6822-41de-82ec-1a2e6332a40a" />
