### PR TITLE
util: properly detect version at which kmod split occurred

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -443,9 +443,11 @@ def is_post_kmod_split_build(path: str) -> bool:
         return True
 
     version: str = path.split("/")[1]
-    if version.startswith("24."):
+    major_version: int = int(version.split(".")[0]) if "." in version else 0
+
+    if major_version >= 24:
         return True
-    if version.startswith("23."):
+    if major_version == 23:
         minor_version = version.split(".")[-1]
         if minor_version == "05-SNAPSHOT" or minor_version >= "6":
             return True

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -249,6 +249,8 @@ def test_check_kmod_split():
         "releases/24.10.0-rc1/targets/x86/64": True,
         "releases/24.10.2/targets/x86/64": True,
         "releases/24.10-SNAPSHOT/targets/x86/64": True,
+        "releases/25.12.2/targets/x86/64": True,
+        "releases/26.10-SNAPSHOT/targets/x86/64": True,
         "snapshots/targets/x86/64": True,
     }
 


### PR DESCRIPTION
A sloppy test for the version at which the kmods directory was split from the platform packages was string based and stopped at version 24.  This caused requests for version 25 platform packages to be incomplete, as there were no kmods included in the response.

Fix this by doing proper comparisons for major version values.