### PR TITLE
asu: build: honor default packages

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -191,7 +191,8 @@ def _build(build_request: BuildRequest, job=None):
             report_error(job, "Could not set up ImageBuilder")
 
     returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(
-        container, ["make", "info"]
+        container, ["make", "info"],
+        copy=[".packageinfo", bin_dir],
     )
 
     job.meta["imagebuilder_status"] = "validate_revision"
@@ -206,12 +207,11 @@ def _build(build_request: BuildRequest, job=None):
                 f"Received incorrect version {version_code} (requested {requested})",
             )
 
-    default_packages = set(
+    target_default_packages = set(
         re.search(r"Default Packages: (.*)\n", job.meta["stdout"]).group(1).split()
-    )
-    log.debug(f"Default packages: {default_packages}")
+    )    
 
-    profile_packages = set(
+    profile_default_packages = set(
         re.search(
             r"{}:\n    .+\n    Packages: (.*?)\n".format(build_request.profile),
             job.meta["stdout"],
@@ -221,13 +221,51 @@ def _build(build_request: BuildRequest, job=None):
         .split()
     )
 
+    default_packages = target_default_packages | profile_default_packages
+    log.debug(f"Default packages: {default_packages}")
+
     apply_package_changes(build_request)
 
     build_cmd_packages = build_request.packages
 
     if build_request.diff_packages:
+        # additional mode - keep default packages which not conflict with user requested packages
+        # Get information about package conflicts and provides from .packageinfo
+        packages_db: dict[str, dict[str, list[str]]] = {}
+        packages_with_conflicts: set[str] = set()
+        with open(str(bin_dir / ".packageinfo"), 'r') as file:
+            pack_blocks = re.findall(
+                r"Package: (.*?)\n.*?\nConflicts: (.*?)\n.*?\nProvides: (.*?)\n",
+                file.read(),
+                re.DOTALL,
+            )
+            for p_name, p_conflicts, p_provides in pack_blocks:    
+                packages_db.update({p_name: {"conflicts": p_conflicts.split(), "provides": p_provides.split()}})
+        
+        # Do not include default packages with potential conflicts (conflicts or provides)
+        for package in default_packages:
+            for package_user in set(build_request.packages) - default_packages:
+                if package in packages_db and package_user in packages_db:
+                    if package in packages_db[package_user]["provides"]:
+                        log.debug(f"{package}\tNOT INCLUDED (Provided by: {package_user})")
+                        packages_with_conflicts.add(package)
+                    if set(packages_db[package]["provides"]) & set(packages_db[package_user]["provides"]):
+                        log.debug(f"{package}\tNOT INCLUDED (Common provides with: {package_user})")
+                        packages_with_conflicts.add(package)
+                    if package in packages_db[package_user]["conflicts"] or package_user in packages_db[package]["conflicts"]:
+                        log.debug(f"{package}\tNOT INCLUDED (Conflict with: {package_user})")
+                        packages_with_conflicts.add(package)
+                
+        for p in packages_with_conflicts:
+            build_cmd_packages.remove(p)
+            build_cmd_packages.insert(0, f"-{p}")
+
+        log.debug(f"List of packages removing default packages with conflicts: {build_cmd_packages}")
+    
+    else:
+        # absolute mode - remove default packages not in requested list
         build_cmd_packages: list[str] = diff_packages(
-            build_request.packages, default_packages | profile_packages
+            build_request.packages, default_packages
         )
         log.debug(f"Diffed packages: {build_cmd_packages}")
 

--- a/asu/build_request.py
+++ b/asu/build_request.py
@@ -98,7 +98,7 @@ class BuildRequest(BaseModel):
         Field(
             description="""
                 This parameter determines if requested packages are seen as
-                *additional* or *absolute*. If set to `true` the packages are
+                *additional* or *absolute*. If set to `false` the packages are
                 seen as *absolute* and all default packages outside the
                 requested packages are removed. \n\n It is possible to brick
                 devices when requesting an incomplete list with this parameter
@@ -106,7 +106,7 @@ class BuildRequest(BaseModel):
                 packages.
             """.strip(),
         ),
-    ] = False
+    ] = True
     defaults: Annotated[
         str | None,
         Field(


### PR DESCRIPTION
Attempt to improve the actual situation where all `asu`'s clients are requesting builds with the parameter `"diff_packages = True"` which means that the list of packages is considered "absolute" and all default packages not included in the list are removed.

This implies that asu's clients need to create a full list of packages. This ends up in a situation where any changes to default packages upstream are not getting reflected on asu's builds, leading to several false positive issue reports where the fix was about modiying the default packages list. https://github.com/openwrt/openwrt/issues/14541#issuecomment-3678898517

Some clients had resolved this more or less successfully, 
- **firmware-selector** for example has almost resolved the issue just putting the actual default packages in the presented input list of packages (gathered from downlads.openwrt.org).
- special mention to **owut** which has done the more complete effort and almost resolved the issue making a complete 
analysis of default packages using several sources of information.
- **luci's attended sysupgrade app** and **auc** are not able to reflect the actually device packages and only request the packages which are installed in the target-device.

So I think that this can be improved on the asu server side,

* There is more info on the server side with the imagebuilder bundles including the .packageinfo files which includes a updated "data base" of all openwrt packages, including feeds, with information about "conflicts" and "provides" of each package.
* This unifies the expected behavior of include default packages when requesting images.
-------------------------------------

The idea is basicly, include all actual default packages which will not conflict with the other user's requested packages, the conflict checks consist on:
- The name of the default package is not in the "conflicts" field of other included package or viceversa.
- The default package's "provides" field(or package name) do not have any common with other included package's provides.

*The fields "conflicts" in the packages's makefiles are not perfect and we need to check for other fields like "provides" to detect potential conflicts between packages.
*The set of default packages is meant to be minimal and well tested so we are not trying to make checks between the huge list off all packages.
*We only are "removing" the default packages which may conflict with other user's specified packages
*This is done by adding the package with prefix "-" to imagebuilder build command.
*ImageBuilder, by default, include all default packages.

This is actually only improving the now unused case/path where "diff_packages = False" (which was meant to be the default) https://github.com/openwrt/asu/blob/e502b67eae25e9fc58a56dfef5276dbec68c9600/asu/build_request.py#L96-L109 and the same functionality is preserved. 
*(In order to make old clients and old installations to Benefit from this change, I propose flip the logic of the parameter, but keeping the old behaviour preserved)

Fixes: https://github.com/openwrt/openwrt/issues/19749
Fixes: all issues related with changes in default packages lists
Fixes: ath10 fixes
Fixes: fitblk inclusion
Fixes: ...