### PR TITLE
asu: revert sanitize 

### DIFF
--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -209,9 +209,6 @@ def api_v1_build_post(
     request: Request,
     user_agent: str = Header(None),
 ):
-    # Sanitize the profile in case the client did not (bug in older LuCI app).
-    build_request.profile = build_request.profile.replace(",", "_")
-
     add_build_event("requests")
 
     request_hash: str = get_request_hash(build_request)

--- a/asu/util.py
+++ b/asu/util.py
@@ -168,7 +168,7 @@ def get_request_hash(build_request: BuildRequest) -> str:
                 build_request.version,
                 build_request.version_code,
                 build_request.target,
-                build_request.profile,
+                build_request.profile.replace(",", "_"),
                 get_packages_hash(
                     build_request.packages_versions.keys() or build_request.packages
                 ),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -537,7 +537,7 @@ def test_api_build_real_ath79(app):
             target="ath79/generic",
             version="23.05.5",
             packages=["tmux", "vim"],
-            profile="8dev,carambola2",  # Test unsanitized profile.
+            profile="8dev_carambola2",
         ),
     )
 


### PR DESCRIPTION
Since it seems there is no enough review time https://github.com/openwrt/asu/pull/1533 and the PR fixing the underlying issue which misleaded to the referenced revert commits has been merged:
- https://github.com/openwrt/openwrt/pull/21095

maybe just reverting to an known working state have better luck.

This would allow to use firmware-selector for the gl-mt2500 MaxLinear PHY case even Owut or Luci ASU app with the workaround of `echo "glinet_gl-mt2500" > /tmp/sysinfo/board_name` for the MaxLinear users.

The key here, IMHO, is that we have to make clearer the difference between "profile" and "DT compatible string" and for that I am thinking about some variable/messages renames could help also, but in order to prioritize, the code implied in the proposed reverts is the key and I think it goes in opposite direction.
https://github.com/openwrt/asu/issues/1525#issuecomment-3497242570
Right now we got this when generating the app.profiles[version][target]
```
{
'glinet_gl-mt2500': 'glinet_gl-mt2500',
'glinet_gl-mt2500-emmc': 'glinet_gl-mt2500',
'glinet_gl-mt2500-airoha': 'glinet_gl-mt2500',
'glinet_gl-mt2500': 'glinet_gl-mt2500',
'glinet_gl-mt2500-airoha': 'glinet_gl-mt2500-airoha',
'glinet_gl-mt2500-emmc': 'glinet_gl-mt2500-airoha',
'glinet_gl-mt2500': 'glinet_gl-mt2500-airoha',
'glinet_gl-mt2500-airoha': 'glinet_gl-mt2500-airoha'
}
which ends up like this: (not working)
{
'glinet_gl-mt2500': 'glinet_gl-mt2500-airoha',
'glinet_mt2500-emmc': 'glinet_gl-mt2500-airoha',
'glinet_gl-mt2500-airoha': 'glinet_gl-mt2500-airoha'
}
```
Before commit "sanitize profile" https://github.com/openwrt/asu/commit/1579236ca291a13b1f9f8b2e2552a776821e642d
```
{
'glinet,gl-mt2500': 'glinet_gl-mt2500',
'glinet,gl-mt2500-emmc': 'glinet_gl-mt2500',
'glinet,gl-mt2500-airoha': 'glinet_gl-mt2500',
'glinet_gl-mt2500': 'glinet_gl-mt2500',
'glinet,gl-mt2500-airoha': 'glinet_gl-mt2500-airoha',
'glinet,gl-mt2500-emmc': 'glinet_gl-mt2500-airoha',
'glinet,gl-mt2500': 'glinet_gl-mt2500-airoha',
'glinet_gl-mt2500-airoha': 'glinet_gl-mt2500-airoha'
}
which ends up like this: (working only works firmware-selector which use the profile directly, no DTS compatible)
{
'glinet,gl-mt2500': 'glinet_gl-mt2500-airoha',
'glinet,mt2500-emmc': 'glinet_gl-mt2500-airoha',
'glinet,gl-mt2500-airoha': 'glinet_gl-mt2500-airoha',
'glinet_gl-mt2500': 'glinet_gl-mt2500',
'glinet_gl-mt2500-airoha': 'glinet_gl-mt2500-airoha'
}
```

This do not implies nothing about which of PR fixing the gl-mt2500 issue in the openwrt repo will be finally merged:
- https://github.com/openwrt/openwrt/pull/20632 or
- https://github.com/openwrt/openwrt/pull/20947