### PR TITLE
build: report package errors with a more detail

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -18,6 +18,7 @@ from asu.util import (
     add_timestamp,
     add_build_event,
     check_manifest,
+    check_package_errors,
     diff_packages,
     error_log,
     fingerprint_pubkey_usign,
@@ -189,7 +190,7 @@ def _build(build_request: BuildRequest, job=None):
         )
         if returncode:
             container.kill()
-            report_error(job, "Could not set up ImageBuilder")
+            report_error(job, f"Could not set up ImageBuilder ({returncode=})")
 
     returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(
         container, ["make", "info"]
@@ -257,7 +258,7 @@ def _build(build_request: BuildRequest, job=None):
 
     if returncode:
         container.kill()
-        report_error(job, "Impossible package selection")
+        report_error(job, check_package_errors(job.meta["stderr"]))
 
     manifest: dict[str, str] = parse_manifest(job.meta["stdout"])
     log.debug(f"Manifest: {manifest}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -449,7 +449,9 @@ def test_api_build_conflicting_packages(client):
 
     assert response.status_code == 500
     data = response.json()
-    assert data["detail"] == "Error: Impossible package selection"
+    assert (
+        data["detail"] == "Error: Impossible package selection: missing (dnsmasq-full)"
+    )
 
 
 def test_api_build_without_packages_list(client):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,6 +8,7 @@ import asu.util
 from asu.build_request import BuildRequest
 from asu.util import (
     check_manifest,
+    check_package_errors,
     diff_packages,
     fingerprint_pubkey_usign,
     get_container_version_tag,
@@ -308,6 +309,22 @@ def test_check_manifest():
     assert (
         check_manifest({"test": "1.0"}, {"test2": "1.0"})
         == "Impossible package selection: test2 not in manifest"
+    )
+
+
+def test_check_package_errors():
+    assert check_package_errors("hello world") == "Impossible package selection"
+    assert (
+        check_package_errors(
+            " * opkg_install_cmd: Cannot install package OPKG-MISSING."
+        )
+        == "Impossible package selection: missing (OPKG-MISSING)"
+    )
+    assert (
+        check_package_errors(check_package_errors.__doc__)
+        == "Impossible package selection:"
+        " missing (APK-MISSING, OPKG-MISSING)"
+        " conflicts (APK-CONFLICT-1, APK-CONFLICT-2, OPKG-CONFLICT-1, OPKG-CONFLICT-2)"
     )
 
 


### PR DESCRIPTION
Preliminary error statistics show that over 80% of all build errors are due to package errors. So instead of just reporting "Impossible package selection", attempt to show whether packages are missing or conflicting and list all packages named in the stderr from the build.

Packaging errors might arise from various causes:

 1) User specifies conflicting packages: nftables-json and nftables-nojson

 2) User specifies or has installed a package not from the OpenWrt feeds

 3) The upstream build of a package has failed, so it's appearing to be missing

This new log information will give us some insight as to whether these errors are caused by the user, the ASU client or upstream builds, so we know where to focus mitigations.