### PR TITLE
build: improve package error name parsing

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -450,7 +450,8 @@ def test_api_build_conflicting_packages(client):
     assert response.status_code == 500
     data = response.json()
     assert (
-        data["detail"] == "Error: Impossible package selection: missing (dnsmasq-full)"
+        data["detail"]
+        == "Error: Impossible package selection: conflicts (dnsmasq, dnsmasq-full)"
     )
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -324,7 +324,8 @@ def test_check_package_errors():
         check_package_errors(check_package_errors.__doc__)
         == "Impossible package selection:"
         " missing (APK-MISSING, OPKG-MISSING)"
-        " conflicts (APK-CONFLICT-1, APK-CONFLICT-2, OPKG-CONFLICT-1, OPKG-CONFLICT-2)"
+        " conflicts (APK-CONFLICT-1, APK-CONFLICT-2, OPKG-CONFLICT-1,"
+        " OPKG-CONFLICT-2, OPKG-CONFLICT-3, OPKG-CONFLICT-4)"
     )
 
 


### PR DESCRIPTION
Add an opkg case for the check_data_file_clashes error, which is reported when two packages attempt to install the same file.

Fix up apk conflicts message parsing, which had a bug the allowed a package name to include a newline.