### PR TITLE
error-log: sanitize job hashes in messages

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -9,7 +9,7 @@ from datetime import datetime, UTC
 from logging.handlers import RotatingFileHandler
 from os import getgid, getuid
 from pathlib import Path
-from re import match, findall, DOTALL, MULTILINE
+from re import match, findall, sub, DOTALL, MULTILINE
 from tarfile import TarFile
 from io import BytesIO
 from typing import Optional
@@ -713,8 +713,9 @@ class ErrorLog:
             error_message: Description of the error
         """
         timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
-        # Sanitize error message: single line, limited length
-        clean_error = " ".join(error_message.split())[:200]
+        # Sanitize error message: remove any job hash, single line, limited length
+        clean_error = sub(r"[0-9a-f]{64}", r"[job-id]", error_message)
+        clean_error = " ".join(clean_error.split())[:200]
         profile_info = (
             f"{build_request.version}:{build_request.target}:{build_request.profile}"
         )

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -220,6 +220,16 @@ def test_build_error_log(client, test_path):
     assert "Build Errors: 2 entries" in summary
     assert "Time range:" in summary
 
+    # Test sanitization of job hashes
+    error_log.log_build_error(
+        build_request,
+        "Internal Server Error (no container with ID "
+        "eee08b3b7b072f2ba82559c6e61da9b84e00cdbc35a4d99392fec36c0bf64356"
+        " found in database: no such container)",
+    )
+    entries = error_log.get_entries()
+    assert " ID [job-id] found " in entries[0]
+
 
 def test_build_error_log_api(client, test_path):
     """Test the /api/v1/build-errors endpoint."""


### PR DESCRIPTION
Plug a potential security hole by removing job hashes from any internal server errors that include them.  See included test case for an example taken from an actual error.