### PR TITLE
fix: add filter='data' to tarfile.extractall() (CVE-2007-4559)

### DIFF
--- a/asu/util.py
+++ b/asu/util.py
@@ -319,7 +319,7 @@ def run_cmd(
                 member.uid = uuid
                 member.gid = ugid
                 member.mode = 0o755 if member.isdir() else 0o644
-            tar_file.extractall(copy[1])
+            tar_file.extractall(copy[1], filter="data")
 
     return returncode, stdout, stderr
 


### PR DESCRIPTION
A malicious container could craft tar archives with path traversal entries (e.g. ../../../etc/crontab) to write files outside the intended extraction directory.

Python 3.12+ supports filter='data' which rejects absolute paths, parent directory references, and other dangerous tar member attributes. This is the recommended mitigation per PEP 706.