### PR TITLE
package-changes: remove any luci-i18n english translations

### DIFF
--- a/asu/package_changes.py
+++ b/asu/package_changes.py
@@ -215,3 +215,8 @@ def apply_package_changes(build_request: BuildRequest):
                     if package.startswith(old):
                         lang = package.replace(old, "")
                         build_request.packages[i] = f"{new}{lang}"
+
+    # Clean out all the no longer present -en translations
+    for package in list(build_request.packages):
+        if package.startswith("luci-i18n-") and package.endswith("-en"):
+            _remove_if_present(package)

--- a/tests/test_package_changes.py
+++ b/tests/test_package_changes.py
@@ -116,17 +116,21 @@ def test_apply_package_changes_lang_packs():
             "target": "mediatek/mt7622",
             "profile": "foobar",
             "packages": [
+                "luci-i18n-english-en",  # Should be deleted
                 "luci-i18n-opkg-ko",  # Should be replaced
                 "luci-i18n-xinetd-lt",  # Should be untouched
+                "luci-i18n-opkg-en",  # Should be deleted
                 "luci-i18n-opkg-zh-cn",  # Should be replaced
             ],
         }
     )
 
-    assert len(build_request.packages) == 3
-    assert build_request.packages[0] == "luci-i18n-opkg-ko"
-    assert build_request.packages[1] == "luci-i18n-xinetd-lt"
-    assert build_request.packages[2] == "luci-i18n-opkg-zh-cn"
+    assert len(build_request.packages) == 5
+    assert build_request.packages[0] == "luci-i18n-english-en"
+    assert build_request.packages[1] == "luci-i18n-opkg-ko"
+    assert build_request.packages[2] == "luci-i18n-xinetd-lt"
+    assert build_request.packages[3] == "luci-i18n-opkg-en"
+    assert build_request.packages[4] == "luci-i18n-opkg-zh-cn"
 
     apply_package_changes(build_request)
 


### PR DESCRIPTION
We're still seeing older upgrades that include the no-longer-existing English translations.

    Impossible package selection: missing (luci-i18n-attendedsysupgrade-en,
        luci-i18n-ddns-en, luci-i18n-openvpn-en, luci-i18n-p910nd-en, ...

Explicitly remove them from the package list.