### PR TITLE
api: add versions to 'latest' API result

### DIFF
--- a/asu/main.py
+++ b/asu/main.py
@@ -127,8 +127,17 @@ def generate_latest():
 
 @app.get("/json/v1/latest.json")
 def json_v1_latest():
+    """Returns two lists:
+
+    1) A list of the latest releases on each branch that is still
+       under support, including any upcoming RC versions.  Sorted by
+       release branch, with newest first.
+
+    2) A list of all available versions (both releases and snapshot),
+       sorted newest first.
+    """
     latest = generate_latest()
-    return {"latest": latest}
+    return {"latest": latest, "versions": app.versions}
 
 
 def generate_branches():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -264,6 +264,13 @@ def test_api_latest_default(client):
     response = client.get("/api/v1/latest", follow_redirects=False)
     assert response.status_code == 301
 
+    response = client.get("/api/v1/latest", follow_redirects=True)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["latest"] == ["24.10.0-rc6", "23.05.5", "22.03.7"]
+    assert data["versions"][0] == "SNAPSHOT"
+    assert data["versions"][-1] == "1.2-SNAPSHOT"
+
 
 def test_api_overview(client):
     response = client.get("/api/v1/overview", follow_redirects=False)


### PR DESCRIPTION
In order to present a valid list of versions, downstream clients are currently parsing the upstream '.versions.json' and synthesizing (or not) a '-SNAPSHOT' version.  Since we're doing this already inside ASU, we might as well make it available to clients.

This will allow us to rewrite Firmware Selector, which has a hard-coded regex to filter unsupported versions (which is currently wrong).  With this change OFS will rely completely on the ASU server to tell it what is available.

Likewise, this allows a cleanup of owut to remove its similar parsing of the branches and .versions files.

It has no impact on LuCI ASU app, as it only uses the 'latest' list from this API call.

----
Additional comments

Should this actually be a new API: `api/v1/versions` instead of piling it onto the existing `api/v1/latest`???  This was simple and all the clients are already grabbing `latest`, so it seems like a good fit, but the endpoint name isn't the greatest.

----
Here's that regex, this PR pretty much eliminates all that code turning it into `versions = get("api/v1/latest").versions` and filtering out the -SNAPSHOT versions if the `show_snapshot` setting is turned off.

https://github.com/openwrt/firmware-selector-openwrt-org/blob/ea04cec0c9a507db3dabbc97ca6b6db4a58258e8/www/index.js#L828