### PR TITLE
build: check profile name before usage

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -234,6 +234,9 @@ def _build(build_request: BuildRequest, job=None):
     )
     log.debug(f"Default packages: {default_packages}")
 
+    if f"\n{build_request.profile}:\n" not in job.meta["stdout"]:
+        report_error(job, f"Invalid device profile: {build_request.profile}")
+
     profile_packages = set(
         re.search(
             r"{}:\n    .+\n    Packages: (.*?)\n".format(build_request.profile),


### PR DESCRIPTION
If the build request contains a device profile that is not contained in the imagebuilder's device list, the build crashes with an internal server error.  This happens when the DTS for the device is incorrect, see link for example.

Fix by checking before attempting to extract data from the imagebuilder output.

Link: https://github.com/openwrt/asu/issues/1583