### PR TITLE
Support S3 remote storage and better container cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv sync --extra dev
 ```
 
+#### Running Redis
+
+```bash
+podman run -d --name redis -p 6379:6379 redis:alpine
+```
+
 #### Running the server
 
 ```bash

--- a/asu/build.py
+++ b/asu/build.py
@@ -114,7 +114,9 @@ def inject_files(container, build_request, job=None):
             elif job:
                 report_error(job, f"Repository {repo} not allowed")
         repositories += "src imagebuilder file:packages\noption check_signature"
-        container.put_archive("/builder/", _make_tar({"repositories.conf": repositories}))
+        container.put_archive(
+            "/builder/", _make_tar({"repositories.conf": repositories})
+        )
 
     if build_request.defaults:
         files = {
@@ -255,7 +257,9 @@ def _build(build_request: BuildRequest, job=None):
 
         apply_package_changes(build_request)
 
-        extra_packages = set(build_request.packages) - default_packages - profile_packages
+        extra_packages = (
+            set(build_request.packages) - default_packages - profile_packages
+        )
         branch = get_branch(build_request.version)["name"]
         for pkg in extra_packages:
             if not pkg.startswith("-"):

--- a/asu/build.py
+++ b/asu/build.py
@@ -255,6 +255,15 @@ def _build(build_request: BuildRequest, job=None):
 
         apply_package_changes(build_request)
 
+        extra_packages = set(build_request.packages) - default_packages - profile_packages
+        branch = get_branch(build_request.version)["name"]
+        for pkg in extra_packages:
+            if not pkg.startswith("-"):
+                add_timestamp(
+                    f"stats:packages:{branch}:{pkg}",
+                    {"stats": "packages", "branch": branch, "package": pkg},
+                )
+
         build_cmd_packages = build_request.packages
 
         if build_request.diff_packages:

--- a/asu/build.py
+++ b/asu/build.py
@@ -2,6 +2,9 @@ import datetime
 import json
 import logging
 import re
+import shutil
+import tarfile
+from io import BytesIO
 from os import getenv
 from pathlib import Path
 from typing import Union
@@ -15,6 +18,7 @@ from podman import errors
 from asu.build_request import BuildRequest
 from asu.config import settings
 from asu.package_changes import apply_package_changes
+from asu.store import LocalStore, get_store
 from asu.util import (
     add_timestamp,
     add_build_event,
@@ -57,6 +61,68 @@ def is_repo_allowed(repo_url: str, allow_list: list[str]) -> bool:
     return False
 
 
+def _cleanup_container(container):
+    """Kill and remove a container with its volumes."""
+    try:
+        container.kill()
+    except Exception:
+        pass
+    try:
+        container.remove(v=True, force=True)
+    except Exception as e:
+        log.warning(f"Failed to remove container {container.id[:12]}: {e}")
+
+
+def _make_tar(files: dict[str, str | bytes]) -> bytes:
+    """Create an in-memory tar archive from a dict of {path: content}.
+
+    Args:
+        files: mapping of archive-relative paths to file contents
+               (str will be encoded to utf-8)
+
+    Returns:
+        bytes of a tar archive
+    """
+    buf = BytesIO()
+    with tarfile.TarFile(fileobj=buf, mode="w") as tar:
+        for name, content in files.items():
+            data = content.encode("utf-8") if isinstance(content, str) else content
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, BytesIO(data))
+    return buf.getvalue()
+
+
+def inject_files(container, build_request, job=None):
+    """Copy keys, repositories, and defaults into a running container.
+
+    Uses put_archive to inject files directly — no bind mounts needed,
+    so there are no host-path dependencies.
+    """
+    if build_request.repository_keys:
+        files = {}
+        for key in build_request.repository_keys:
+            fingerprint = fingerprint_pubkey_usign(key)
+            files[f"keys/{fingerprint}"] = f"untrusted comment: {fingerprint}\n{key}"
+        container.put_archive("/builder/", _make_tar(files))
+
+    if build_request.repositories:
+        repositories = ""
+        for name, repo in build_request.repositories.items():
+            if is_repo_allowed(repo, settings.repository_allow_list):
+                repositories += f"src/gz {name} {repo}\n"
+            elif job:
+                report_error(job, f"Repository {repo} not allowed")
+        repositories += "src imagebuilder file:packages\noption check_signature"
+        container.put_archive("/builder/", _make_tar({"repositories.conf": repositories}))
+
+    if build_request.defaults:
+        files = {
+            "asu-files/etc/uci-defaults/99-asu-defaults": build_request.defaults,
+        }
+        container.put_archive("/builder/", _make_tar(files))
+
+
 def _build(build_request: BuildRequest, job=None):
     """Build image request and setup ImageBuilders automatically
 
@@ -69,6 +135,7 @@ def _build(build_request: BuildRequest, job=None):
     build_start: float = perf_counter()
 
     request_hash = get_request_hash(build_request)
+
     bin_dir: Path = settings.public_path / "store" / request_hash
     bin_dir.mkdir(parents=True, exist_ok=True)
     log.debug(f"Bin dir: {bin_dir}")
@@ -90,7 +157,6 @@ def _build(build_request: BuildRequest, job=None):
         f"Container version: {container_version_tag} (requested {build_request.version})"
     )
 
-    mounts: list[dict[str, Union[str, bool]]] = []
     environment: dict[str, str] = {}
 
     image = f"{settings.base_container}:{build_request.target.replace('/', '-')}-{container_version_tag}"
@@ -127,69 +193,9 @@ def _build(build_request: BuildRequest, job=None):
         )
     log.info(f"Pulling {image}... done")
 
-    bin_dir.mkdir(parents=True, exist_ok=True)
-    log.debug("Created store path: %s", bin_dir)
-
-    if build_request.repository_keys:
-        log.debug("Found extra keys")
-
-        (bin_dir / "keys").mkdir(parents=True, exist_ok=True)
-
-        for key in build_request.repository_keys:
-            fingerprint = fingerprint_pubkey_usign(key)
-            log.debug(f"Found key {fingerprint}")
-
-            (bin_dir / "keys" / fingerprint).write_text(
-                f"untrusted comment: {fingerprint}\n{key}"
-            )
-
-            mounts.append(
-                {
-                    "type": "bind",
-                    "source": str(bin_dir / "keys" / fingerprint),
-                    "target": "/builder/keys/" + fingerprint,
-                    "read_only": True,
-                },
-            )
-
-    if build_request.repositories:
-        log.debug("Found extra repos")
-        repositories = ""
-        for name, repo in build_request.repositories.items():
-            if is_repo_allowed(repo, settings.repository_allow_list):
-                repositories += f"src/gz {name} {repo}\n"
-            else:
-                report_error(job, f"Repository {repo} not allowed")
-
-        repositories += "src imagebuilder file:packages\noption check_signature"
-
-        (bin_dir / "repositories.conf").write_text(repositories)
-
-        mounts.append(
-            {
-                "type": "bind",
-                "source": str(bin_dir / "repositories.conf"),
-                "target": "/builder/repositories.conf",
-                "read_only": True,
-            },
-        )
-
-    if build_request.defaults:
-        log.debug("Found defaults")
-
-        defaults_file = bin_dir / "files/etc/uci-defaults/99-asu-defaults"
-        defaults_file.parent.mkdir(parents=True, exist_ok=True)
-        defaults_file.write_text(build_request.defaults)
-        mounts.append(
-            {
-                "type": "bind",
-                "source": str(bin_dir / "files"),
-                "target": str(bin_dir / "files"),
-                "read_only": True,
-            },
-        )
-
-    log.debug("Mounts: %s", mounts)
+    mounts: list[dict[str, Union[str, bool]]] = [
+        {"type": "tmpfs", "target": f"/builder/{request_hash}"},
+    ]
 
     container = podman.containers.create(
         image,
@@ -199,127 +205,131 @@ def _build(build_request: BuildRequest, job=None):
         no_new_privileges=True,
         privileged=False,
         network_mode="pasta",
-        auto_remove=True,
         environment=environment,
+        image_volume_mode="ignore",
     )
-    container.start()
+    try:
+        container.start()
+        inject_files(container, build_request, job)
 
-    if is_snapshot_build(build_request.version):
-        log.info("Running setup.sh for ImageBuilder")
+        if is_snapshot_build(build_request.version):
+            log.info("Running setup.sh for ImageBuilder")
+            returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(
+                container, ["sh", "setup.sh"]
+            )
+            if returncode:
+                report_error(job, f"Could not set up ImageBuilder ({returncode=})")
+
         returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(
-            container, ["sh", "setup.sh"]
+            container, ["make", "info"]
         )
-        if returncode:
-            container.kill()
-            report_error(job, f"Could not set up ImageBuilder ({returncode=})")
 
-    returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(
-        container, ["make", "info"]
-    )
+        job.meta["imagebuilder_status"] = "validate_revision"
+        job.save_meta()
 
-    job.meta["imagebuilder_status"] = "validate_revision"
-    job.save_meta()
+        version_code = re.search('Current Revision: "(r.+)"', job.meta["stdout"]).group(
+            1
+        )
 
-    version_code = re.search('Current Revision: "(r.+)"', job.meta["stdout"]).group(1)
+        if requested := build_request.version_code:
+            if version_code != requested:
+                report_error(
+                    job,
+                    f"Received incorrect version {version_code} (requested {requested})",
+                )
 
-    if requested := build_request.version_code:
-        if version_code != requested:
-            report_error(
-                job,
-                f"Received incorrect version {version_code} (requested {requested})",
+        default_packages = set(
+            re.search(r"Default Packages: (.*)\n", job.meta["stdout"]).group(1).split()
+        )
+        log.debug(f"Default packages: {default_packages}")
+
+        profile_packages = set(
+            re.search(
+                r"{}:\n    .+\n    Packages: (.*?)\n".format(build_request.profile),
+                job.meta["stdout"],
+                re.MULTILINE,
+            )
+            .group(1)
+            .split()
+        )
+
+        apply_package_changes(build_request)
+
+        build_cmd_packages = build_request.packages
+
+        if build_request.diff_packages:
+            build_cmd_packages: list[str] = diff_packages(
+                build_request.packages, default_packages | profile_packages
+            )
+            log.debug(f"Diffed packages: {build_cmd_packages}")
+
+        job.meta["imagebuilder_status"] = "validate_manifest"
+        job.save_meta()
+
+        if settings.squid_cache and not is_snapshot_build(build_request.version):
+            log.info("Disabling HTTPS for repositories")
+            run_cmd(
+                container,
+                ["sed", "-i", "s|https|http|g", "repositories.conf", "repositories"],
             )
 
-    default_packages = set(
-        re.search(r"Default Packages: (.*)\n", job.meta["stdout"]).group(1).split()
-    )
-    log.debug(f"Default packages: {default_packages}")
-
-    profile_packages = set(
-        re.search(
-            r"{}:\n    .+\n    Packages: (.*?)\n".format(build_request.profile),
-            job.meta["stdout"],
-            re.MULTILINE,
-        )
-        .group(1)
-        .split()
-    )
-
-    apply_package_changes(build_request)
-
-    build_cmd_packages = build_request.packages
-
-    if build_request.diff_packages:
-        build_cmd_packages: list[str] = diff_packages(
-            build_request.packages, default_packages | profile_packages
-        )
-        log.debug(f"Diffed packages: {build_cmd_packages}")
-
-    job.meta["imagebuilder_status"] = "validate_manifest"
-    job.save_meta()
-
-    if settings.squid_cache and not is_snapshot_build(build_request.version):
-        log.info("Disabling HTTPS for repositories")
-        run_cmd(
+        returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(
             container,
-            ["sed", "-i", "s|https|http|g", "repositories.conf", "repositories"],
+            [
+                "make",
+                "manifest",
+                f"PROFILE={build_request.profile}",
+                f"PACKAGES={' '.join(build_cmd_packages)}",
+                "STRIP_ABI=1",
+            ],
         )
 
-    returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(
-        container,
-        [
+        job.save_meta()
+
+        if returncode:
+            report_error(job, check_package_errors(job.meta["stderr"]))
+
+        manifest: dict[str, str] = parse_manifest(job.meta["stdout"])
+        log.debug(f"Manifest: {manifest}")
+
+        # Check if all requested packages are in the manifest
+        if err := check_manifest(manifest, build_request.packages_versions):
+            report_error(job, err)
+
+        packages_hash: str = get_packages_hash(manifest.keys())
+        log.debug(f"Packages Hash: {packages_hash}")
+
+        job.meta["build_cmd"] = [
             "make",
-            "manifest",
+            "image",
             f"PROFILE={build_request.profile}",
             f"PACKAGES={' '.join(build_cmd_packages)}",
-            "STRIP_ABI=1",
-        ],
-    )
+            f"EXTRA_IMAGE_NAME={packages_hash[:12]}",
+            f"BIN_DIR=/builder/{request_hash}",
+        ]
 
-    job.save_meta()
+        if build_request.defaults:
+            job.meta["build_cmd"].append("FILES=/builder/asu-files")
 
-    if returncode:
-        container.kill()
-        report_error(job, check_package_errors(job.meta["stderr"]))
+        # Check if custom rootfs size is requested
+        if build_request.rootfs_size_mb:
+            log.debug("Found custom rootfs size %d", build_request.rootfs_size_mb)
+            job.meta["build_cmd"].append(
+                f"ROOTFS_PARTSIZE={build_request.rootfs_size_mb}"
+            )
 
-    manifest: dict[str, str] = parse_manifest(job.meta["stdout"])
-    log.debug(f"Manifest: {manifest}")
+        log.debug("Build command: %s", job.meta["build_cmd"])
 
-    # Check if all requested packages are in the manifest
-    if err := check_manifest(manifest, build_request.packages_versions):
-        report_error(job, err)
+        job.meta["imagebuilder_status"] = "building_image"
+        job.save_meta()
 
-    packages_hash: str = get_packages_hash(manifest.keys())
-    log.debug(f"Packages Hash: {packages_hash}")
-
-    job.meta["build_cmd"] = [
-        "make",
-        "image",
-        f"PROFILE={build_request.profile}",
-        f"PACKAGES={' '.join(build_cmd_packages)}",
-        f"EXTRA_IMAGE_NAME={packages_hash[:12]}",
-        f"BIN_DIR=/builder/{request_hash}",
-    ]
-
-    if build_request.defaults:
-        job.meta["build_cmd"].append(f"FILES={bin_dir}/files")
-
-    # Check if custom rootfs size is requested
-    if build_request.rootfs_size_mb:
-        log.debug("Found custom rootfs size %d", build_request.rootfs_size_mb)
-        job.meta["build_cmd"].append(f"ROOTFS_PARTSIZE={build_request.rootfs_size_mb}")
-
-    log.debug("Build command: %s", job.meta["build_cmd"])
-
-    job.meta["imagebuilder_status"] = "building_image"
-    job.save_meta()
-
-    returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(
-        container,
-        job.meta["build_cmd"],
-        copy=["/builder/" + request_hash, bin_dir.parent],
-    )
-
-    container.kill()
+        returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(
+            container,
+            job.meta["build_cmd"],
+            copy=["/builder/" + request_hash, bin_dir.parent],
+        )
+    finally:
+        _cleanup_container(container)
 
     job.save_meta()
 
@@ -381,40 +391,49 @@ def _build(build_request: BuildRequest, job=None):
                 {
                     "type": "bind",
                     "source": str(bin_dir),
-                    "target": request_hash,
+                    "target": "/work",
                     "read_only": False,
                 },
             ],
-            user="root",  # running as root to have write access to the mounted volume
-            working_dir=request_hash,
+            user="root",
+            working_dir="/work",
             environment={
                 "IMAGES_TO_SIGN": " ".join(images),
                 "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/builder/staging_dir/host/bin",
             },
-            auto_remove=True,
+            image_volume_mode="ignore",
         )
-        returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(
-            container,
-            [
-                "bash",
-                "-c",
-                (
-                    "env;"
-                    "for IMAGE in $IMAGES_TO_SIGN; do "
-                    "touch ${IMAGE}.test;"
-                    'fwtool -t -s /dev/null "$IMAGE" && echo "sign entfern";'
-                    'cp "/builder/key-build.ucert" "$IMAGE.ucert" && echo "moved";'
-                    'usign -S -m "$IMAGE" -s "/builder/key-build" -x "$IMAGE.sig"  && echo "usign";'
-                    'ucert -A -c "$IMAGE.ucert" -x "$IMAGE.sig" && echo "ucert";'
-                    'fwtool -S "$IMAGE.ucert" "$IMAGE" && echo "fwtool";'
-                    "done"
-                ),
-            ],
-        )
-        container.stop()
+        try:
+            container.start()
+            returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(
+                container,
+                [
+                    "bash",
+                    "-c",
+                    (
+                        "env;"
+                        "for IMAGE in $IMAGES_TO_SIGN; do "
+                        "touch ${IMAGE}.test;"
+                        'fwtool -t -s /dev/null "$IMAGE" && echo "sign entfern";'
+                        'cp "/builder/key-build.ucert" "$IMAGE.ucert" && echo "moved";'
+                        'usign -S -m "$IMAGE" -s "/builder/key-build" -x "$IMAGE.sig"  && echo "usign";'
+                        'ucert -A -c "$IMAGE.ucert" -x "$IMAGE.sig" && echo "ucert";'
+                        'fwtool -S "$IMAGE.ucert" "$IMAGE" && echo "fwtool";'
+                        "done"
+                    ),
+                ],
+            )
+        finally:
+            _cleanup_container(container)
         job.save_meta()
     else:
         log.warning("No build key found, skipping signing")
+
+    store = get_store()
+    store.upload_dir(bin_dir, request_hash)
+
+    if not isinstance(store, LocalStore):
+        shutil.rmtree(bin_dir, ignore_errors=True)
 
     json_content.update({"manifest": manifest})
     json_content.update(json_content["profiles"][build_request.profile])

--- a/asu/config.py
+++ b/asu/config.py
@@ -99,9 +99,10 @@ class Settings(BaseSettings):
     server_stats: str = ""
     log_level: str = "INFO"
     squid_cache: bool = False
-    build_ttl: str = "3h"
+    build_ttl: str = "7d"
+    build_ttl_unversioned: str = "24h"
     build_defaults_ttl: str = "30m"
-    build_failure_ttl: str = "10m"
+    build_failure_ttl: str = "1h"
     max_pending_jobs: int = 200
     job_timeout: str = "10m"
 

--- a/asu/config.py
+++ b/asu/config.py
@@ -89,6 +89,13 @@ class Settings(BaseSettings):
         "22.03": release(19160),
         "21.02": release(15812, enabled=True),  # Enabled for now...
     }
+    store_backend: str = "local"  # "local" or "s3"
+    s3_endpoint: str = ""
+    s3_access_key: str = ""
+    s3_secret_key: str = ""
+    s3_bucket: str = "asu-store"
+    s3_region: str = ""
+    s3_public_url: str = ""  # base URL for redirects, e.g. "https://cdn.example.com"
     server_stats: str = ""
     log_level: str = "INFO"
     squid_cache: bool = False

--- a/asu/main.py
+++ b/asu/main.py
@@ -12,6 +12,7 @@ from fastapi.templating import Jinja2Templates
 from asu import __version__
 from asu.config import settings
 from asu.routers import api, stats
+from asu.store import LocalStore, get_store
 from asu.util import (
     client_get,
     get_branch,
@@ -48,16 +49,22 @@ app.profiles = defaultdict(lambda: defaultdict(dict))
 
 @app.api_route("/store/{path:path}", methods=["GET", "HEAD"])
 def store(path: str):
-    path = (settings.public_path / "store" / path).resolve()
-    if not path.is_file() or settings.public_path / "store" not in path.parents:
-        raise HTTPException(status_code=404, detail="Not found")
+    store_backend = get_store()
 
-    return FileResponse(
-        path,
-        media_type="application/octet-stream",
-        filename=path.name,  # adds Content-Disposition: attachment; filename="..."
-        headers={"X-Content-Type-Options": "nosniff"},
-    )
+    if isinstance(store_backend, LocalStore):
+        store_root = (settings.public_path / "store").resolve()
+        file_path = (store_root / path).resolve()
+        if not file_path.is_file() or store_root not in file_path.parents:
+            raise HTTPException(status_code=404, detail="Not found")
+
+        return FileResponse(
+            file_path,
+            media_type="application/octet-stream",
+            filename=file_path.name,
+            headers={"X-Content-Type-Options": "nosniff"},
+        )
+
+    return RedirectResponse(store_backend.get_url(path), status_code=302)
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/asu/main.py
+++ b/asu/main.py
@@ -84,6 +84,17 @@ def index(request: Request):
     )
 
 
+@app.get("/stats", response_class=HTMLResponse)
+def stats_page(request: Request):
+    return templates.TemplateResponse(
+        request=request,
+        name="stats.html",
+        context=dict(
+            branches=reversed(settings.branches),
+        ),
+    )
+
+
 @app.get("/json/v1/{path:path}/index.json")
 def json_v1_target_index(path: str) -> dict[str, Union[str, dict[str, str]]]:
     base_path: str = f"{settings.upstream_url}/{path}"

--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -217,9 +217,12 @@ def api_v1_build_post(
     request_hash: str = get_request_hash(build_request)
     job: Job = get_queue().fetch_job(request_hash)
     status: int = 200
-    result_ttl: str = settings.build_ttl
     if build_request.defaults:
         result_ttl = settings.build_defaults_ttl
+    elif build_request.packages_versions:
+        result_ttl = settings.build_ttl
+    else:
+        result_ttl = settings.build_ttl_unversioned
     failure_ttl: str = settings.build_failure_ttl
 
     if build_request.client:

--- a/asu/routers/stats.py
+++ b/asu/routers/stats.py
@@ -181,7 +181,9 @@ def get_top_packages(branch: str = None, n: int = 30) -> dict:
     sorted_packages = sorted(packages.items(), key=lambda x: x[1], reverse=True)[:n]
 
     return {
-        "packages": [{"name": name, "count": int(count)} for name, count in sorted_packages],
+        "packages": [
+            {"name": name, "count": int(count)} for name, count in sorted_packages
+        ],
         "branch": branch,
         "days": N_DAYS,
     }

--- a/asu/routers/stats.py
+++ b/asu/routers/stats.py
@@ -3,7 +3,7 @@ from datetime import datetime as dt, timedelta, UTC
 from fastapi import APIRouter
 from fastapi.responses import PlainTextResponse
 
-from asu.util import error_log, get_redis_ts
+from asu.util import error_log, get_queue, get_redis_ts
 
 router = APIRouter()
 
@@ -25,6 +25,33 @@ def start_stop(duration, interval):
     labels = [str(dt.fromtimestamp(stamp // 1000, UTC))[:10] + "Z" for stamp in stamps]
 
     return start, stop, stamps, labels
+
+
+@router.get("/stats/summary")
+def get_stats_summary() -> dict:
+    """Return queue length and builds in last 24 hours."""
+    ts = get_redis_ts()
+    rc = ts.client
+
+    now = int(dt.now(UTC).timestamp() * 1000)
+    day_ago = now - DAY_MS
+
+    builds_24h = 0
+    key = "stats:build:successes"
+    if rc.exists(key):
+        result = ts.range(
+            key,
+            from_time=day_ago,
+            to_time=now,
+            aggregation_type="sum",
+            bucket_size_msec=DAY_MS,
+        )
+        builds_24h = int(sum(v for _, v in result))
+
+    return {
+        "queue_length": len(get_queue()),
+        "builds_24h": builds_24h,
+    }
 
 
 @router.get("/builds-per-day")
@@ -120,6 +147,43 @@ def get_builds_by_version(branch: str = None) -> dict():
             }
             for version in sorted(bucket)
         ],
+    }
+
+
+@router.get("/top-packages")
+def get_top_packages(branch: str = None, n: int = 30) -> dict:
+    """Return the most requested packages, optionally filtered by branch."""
+    n = min(n, 100)
+    interval = N_DAYS * DAY_MS
+
+    start, stop, stamps, labels = start_stop(N_DAYS, DAY_MS)
+
+    filters = ["stats=packages"]
+    if branch:
+        filters.append(f"branch={branch}")
+
+    result = get_redis_ts().mrange(
+        filters=filters,
+        with_labels=True,
+        from_time=start,
+        to_time=stop,
+        aggregation_type="sum",
+        bucket_size_msec=interval,
+    )
+
+    packages = {}
+    for row in result:
+        for data in row.values():
+            pkg = data[0].get("package", "unknown")
+            total = sum(v for _, v in data[1])
+            packages[pkg] = packages.get(pkg, 0) + total
+
+    sorted_packages = sorted(packages.items(), key=lambda x: x[1], reverse=True)[:n]
+
+    return {
+        "packages": [{"name": name, "count": int(count)} for name, count in sorted_packages],
+        "branch": branch,
+        "days": N_DAYS,
     }
 
 

--- a/asu/static/style.css
+++ b/asu/static/style.css
@@ -117,7 +117,7 @@ header > div {
     color: #fff;
 }
 
-header > div > img {
+header > div img {
     height: 3em;
     padding: 0.75em;
 }

--- a/asu/store.py
+++ b/asu/store.py
@@ -1,0 +1,101 @@
+import logging
+import mimetypes
+from pathlib import Path
+from typing import Protocol
+
+import boto3
+
+from asu.config import settings
+
+log = logging.getLogger("rq.worker")
+
+
+class Store(Protocol):
+    def upload_file(self, local_path: Path, key: str) -> None: ...
+    def upload_dir(self, local_dir: Path, prefix: str) -> None: ...
+    def get_url(self, key: str) -> str: ...
+    def exists(self, key: str) -> bool: ...
+
+
+class LocalStore:
+    def __init__(self):
+        self.base = settings.public_path / "store"
+        self.base.mkdir(parents=True, exist_ok=True)
+
+    def upload_file(self, local_path: Path, key: str) -> None:
+        dest = self.base / key
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if local_path.resolve() != dest.resolve():
+            import shutil
+
+            shutil.copy2(local_path, dest)
+
+    def upload_dir(self, local_dir: Path, prefix: str) -> None:
+        for path in local_dir.rglob("*"):
+            if path.is_file():
+                key = f"{prefix}/{path.relative_to(local_dir)}"
+                self.upload_file(path, key)
+
+    def get_url(self, key: str) -> str:
+        return f"/store/{key}"
+
+    def exists(self, key: str) -> bool:
+        return (self.base / key).is_file()
+
+    def get_local_path(self, key: str) -> Path:
+        return self.base / key
+
+
+class S3Store:
+    def __init__(self):
+        kwargs = {"service_name": "s3"}
+        if settings.s3_endpoint:
+            kwargs["endpoint_url"] = settings.s3_endpoint
+        if settings.s3_access_key:
+            kwargs["aws_access_key_id"] = settings.s3_access_key
+            kwargs["aws_secret_access_key"] = settings.s3_secret_key
+        if settings.s3_region:
+            kwargs["region_name"] = settings.s3_region
+
+        self._client = boto3.client(**kwargs)
+        self._bucket = settings.s3_bucket
+
+    def upload_file(self, local_path: Path, key: str) -> None:
+        content_type = (
+            mimetypes.guess_type(str(local_path))[0] or "application/octet-stream"
+        )
+        self._client.upload_file(
+            str(local_path),
+            self._bucket,
+            f"store/{key}",
+            ExtraArgs={"ContentType": content_type},
+        )
+        log.debug(f"Uploaded {local_path} to s3://{self._bucket}/store/{key}")
+
+    def upload_dir(self, local_dir: Path, prefix: str) -> None:
+        for path in local_dir.rglob("*"):
+            if path.is_file():
+                key = f"{prefix}/{path.relative_to(local_dir)}"
+                self.upload_file(path, key)
+
+    def get_url(self, key: str) -> str:
+        if settings.s3_public_url:
+            return f"{settings.s3_public_url.rstrip('/')}/store/{key}"
+        return self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self._bucket, "Key": f"store/{key}"},
+            ExpiresIn=3600,
+        )
+
+    def exists(self, key: str) -> bool:
+        try:
+            self._client.head_object(Bucket=self._bucket, Key=f"store/{key}")
+            return True
+        except self._client.exceptions.ClientError:
+            return False
+
+
+def get_store() -> Store:
+    if settings.store_backend == "s3":
+        return S3Store()
+    return LocalStore()

--- a/asu/templates/overview.html
+++ b/asu/templates/overview.html
@@ -72,21 +72,11 @@
                     </ul>
 
                     {% if server_stats %}
-                    <div class="grid-item">
-                        <h2>Builds per Day (last 30 days)</h2>
-                        <canvas id="buildsChart" width="600" height="300"></canvas>
-                    </div>
-                    <div class="grid-item">
-                        <h2>Weekly build counts by branch (last 6 months)
-                            <select name="branchName" id="branchName" onchange="loadVersions()">
-                                <option value="">All</option>
-                                {% for branch in branches %}
-                                <option value="{{ branch }}">{{ branch }}</option>
-                                {%- endfor -%}
-                            </select>
-                        </h2>
-                        <canvas id="versionChart" width="600" height="300"></canvas>
-                    </div>
+                    <p>
+                        <b>Queue length:</b> <span id="queue-length">...</span> |
+                        <b>Builds (24h):</b> <span id="builds-24h">...</span> |
+                        <a href="/stats">Detailed statistics</a>
+                    </p>
                     {% endif %}
 
                     <details>
@@ -142,55 +132,13 @@
         </script>
 
 {% if server_stats %}
-        <script src="static/chart.js"></script>
         <script>
-            async function loadChart(chartSource, canvas) {
-                const response = await fetch(`/api/v1/${chartSource}`);
-                const data = await response.json();
-
-                const oldChart = Chart.getChart(canvas);
-                if (oldChart !== undefined) {
-                    oldChart.destroy();
-                }
-
-                const countChart = new Chart(document.getElementById(canvas), {
-                    type: "line",
-                    data: {
-                        labels: data.labels,
-                        datasets: data.datasets.map(ds => ({
-                            data: ds.data,
-                            label: ds.label,
-                            backgroundColor: ds.color,
-                            borderColor: ds.color,
-                            borderJoinStyle: "round",
-                            fill: false
-                        }))
-                    },
-                    options: {
-                        responsive: true,
-                        scales: {
-                            x: { display: false },
-                            y: { display: true }
-                        },
-                        plugins: {
-                            legend: { display: true },
-                            title:  { display: false }
-                        }
-                    }
+            fetch("/api/v1/stats/summary")
+                .then(r => r.json())
+                .then(data => {
+                    document.getElementById("queue-length").textContent = data.queue_length;
+                    document.getElementById("builds-24h").textContent = data.builds_24h;
                 });
-            }
-
-            loadChart("builds-per-day", "buildsChart");
-
-            function loadVersions() {
-                let branch = document.getElementById("branchName").value;
-                if (branch != "") {
-                    branch = `?branch=${branch}`;
-                }
-                loadChart(`builds-by-version${branch}`, "versionChart");
-            }
-
-            loadVersions();
         </script>
 {% endif %}
 

--- a/asu/templates/stats.html
+++ b/asu/templates/stats.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>OpenWrt Sysupgrade Server - Statistics</title>
+        <link href="/static/style.css" rel="stylesheet" />
+    </head>
+    <body>
+        <header>
+            <div>
+                <a href="/"><img src="/static/logo.png" alt="OpenWrt Firmware logo" /></a>
+            </div>
+        </header>
+        <div class="container">
+            <h1><a href="/" style="color:inherit">Sysupgrade Server</a> - Statistics</h1>
+
+            <div class="grid-container">
+                <div class="grid-item">
+                    <h2>Builds per Day (last 30 days)</h2>
+                    <canvas id="buildsChart" width="600" height="300"></canvas>
+                </div>
+                <div class="grid-item">
+                    <h2>Weekly build counts by branch (last 6 months)
+                        <select name="branchName" id="branchName" onchange="loadVersions()">
+                            <option value="">All</option>
+                            {% for branch in branches %}
+                            <option value="{{ branch }}">{{ branch }}</option>
+                            {%- endfor -%}
+                        </select>
+                    </h2>
+                    <canvas id="versionChart" width="600" height="300"></canvas>
+                </div>
+                <div class="grid-item">
+                    <h2>Top Packages (last 30 days)
+                        <select id="packageBranch" onchange="loadPackages()">
+                            <option value="">All</option>
+                            {% for branch in branches %}
+                            <option value="{{ branch }}">{{ branch }}</option>
+                            {%- endfor -%}
+                        </select>
+                    </h2>
+                    <table id="packagesTable" class="packages-table">
+                        <thead><tr><th>Package</th><th>Requests</th></tr></thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <script src="/static/chart.js"></script>
+        <script>
+            async function loadChart(chartSource, canvas) {
+                const response = await fetch(`/api/v1/${chartSource}`);
+                const data = await response.json();
+
+                const oldChart = Chart.getChart(canvas);
+                if (oldChart !== undefined) {
+                    oldChart.destroy();
+                }
+
+                const countChart = new Chart(document.getElementById(canvas), {
+                    type: "line",
+                    data: {
+                        labels: data.labels,
+                        datasets: data.datasets.map(ds => ({
+                            data: ds.data,
+                            label: ds.label,
+                            backgroundColor: ds.color,
+                            borderColor: ds.color,
+                            borderJoinStyle: "round",
+                            fill: false
+                        }))
+                    },
+                    options: {
+                        responsive: true,
+                        scales: {
+                            x: { display: false },
+                            y: { display: true }
+                        },
+                        plugins: {
+                            legend: { display: true },
+                            title:  { display: false }
+                        }
+                    }
+                });
+            }
+
+            loadChart("builds-per-day", "buildsChart");
+
+
+            function loadVersions() {
+                let branch = document.getElementById("branchName").value;
+                if (branch != "") {
+                    branch = `?branch=${branch}`;
+                }
+                loadChart(`builds-by-version${branch}`, "versionChart");
+            }
+
+            loadVersions();
+
+            async function loadPackages() {
+                let branch = document.getElementById("packageBranch").value;
+                let url = "/api/v1/top-packages";
+                if (branch) url += `?branch=${branch}`;
+                const response = await fetch(url);
+                const data = await response.json();
+                const tbody = document.querySelector("#packagesTable tbody");
+                tbody.innerHTML = data.packages.map(p =>
+                    `<tr><td>${p.name}</td><td>${p.count}</td></tr>`
+                ).join("");
+            }
+
+            loadPackages();
+        </script>
+
+    </body>
+</html>

--- a/env.workers
+++ b/env.workers
@@ -1,0 +1,8 @@
+REDIS_URL=redis://redis-host:6379
+CONTAINER_SOCKET_PATH=/run/user/1000/podman/podman.sock
+STORE_BACKEND=s3
+S3_ENDPOINT=https://your-s3-endpoint.com
+S3_ACCESS_KEY=changeme
+S3_SECRET_KEY=changeme
+S3_BUCKET=asu-store
+S3_REGION=auto

--- a/podman-compose.workers.yml
+++ b/podman-compose.workers.yml
@@ -1,0 +1,35 @@
+# Decentralized worker setup with S3 storage.
+#
+# Workers upload built images to S3 instead of requiring a shared filesystem
+# with the server. This allows workers to run on separate machines.
+#
+# Usage:
+#   cp env.workers .env
+#   podman-compose -f podman-compose.workers.yml up -d
+#
+# Required .env variables:
+#   REDIS_URL           - Redis connection string (must be reachable by workers)
+#   CONTAINER_SOCKET_PATH - Podman socket path
+#   PUBLIC_PATH         - Host path for build output staging
+#   STORE_BACKEND=s3
+#   S3_ENDPOINT         - S3-compatible endpoint URL
+#   S3_ACCESS_KEY       - S3 access key
+#   S3_SECRET_KEY       - S3 secret key
+#   S3_BUCKET           - S3 bucket name
+#   S3_REGION           - S3 region (use "auto" for Cloudflare R2)
+#   S3_PUBLIC_URL       - Public URL for serving images (optional)
+
+services:
+  worker:
+    image: "docker.io/openwrt/asu:latest"
+    build:
+      context: .
+      dockerfile: Containerfile
+    restart: unless-stopped
+    command: uv run rqworker --logging_level INFO
+    env_file: .env
+    volumes:
+      - $CONTAINER_SOCKET_PATH:$CONTAINER_SOCKET_PATH:rw
+      - ${PUBLIC_PATH:-./public}:${PUBLIC_PATH:-./public}:rw
+    deploy:
+      replicas: ${WORKER_REPLICAS:-1}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["asu"]
+
 [project]
 name = "asu"
 version = "0.0.0"
@@ -18,6 +25,7 @@ dependencies = [
     "fastapi-cache2>=0.2.2",
     "httpx>=0.28.1",
     "podman-compose>=1.5.0",
+    "boto3>=1.35.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-import shutil
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -83,10 +81,8 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture
-def test_path():
-    test_path = tempfile.mkdtemp(dir=Path.cwd() / "tests")
-    yield test_path
-    shutil.rmtree(test_path)
+def test_path(tmp_path):
+    return str(tmp_path)
 
 
 @pytest.fixture
@@ -98,6 +94,7 @@ def app(redis_server, test_path, monkeypatch, upstream):
         return Queue(connection=redis_server, is_async=settings.async_queue)
 
     settings.public_path = Path(test_path) / "public"
+    settings.store_backend = "local"
     settings.async_queue = False
     settings.upstream_url = "http://localhost:8123"
     settings.server_stats = "stats"

--- a/tests/test_build_mounts.py
+++ b/tests/test_build_mounts.py
@@ -29,10 +29,12 @@ def test_make_tar_single_file():
 
 
 def test_make_tar_multiple_files():
-    data = _make_tar({
-        "a.txt": "aaa",
-        "sub/b.txt": "bbb",
-    })
+    data = _make_tar(
+        {
+            "a.txt": "aaa",
+            "sub/b.txt": "bbb",
+        }
+    )
     files = _extract_tar(data)
     assert files["a.txt"] == "aaa"
     assert files["sub/b.txt"] == "bbb"

--- a/tests/test_build_mounts.py
+++ b/tests/test_build_mounts.py
@@ -1,0 +1,134 @@
+"""Test build file injection logic (keys, repos, defaults).
+
+Tests verify that _make_tar produces correct archives and that
+inject_files constructs the right file trees for the container.
+"""
+
+import tarfile
+from io import BytesIO
+from unittest.mock import MagicMock
+
+from asu.build import _make_tar, inject_files
+from asu.build_request import BuildRequest
+
+
+def _extract_tar(data: bytes) -> dict[str, str]:
+    """Helper: extract tar bytes into {name: content} dict."""
+    result = {}
+    with tarfile.open(fileobj=BytesIO(data)) as tar:
+        for member in tar.getmembers():
+            if member.isfile():
+                result[member.name] = tar.extractfile(member).read().decode("utf-8")
+    return result
+
+
+def test_make_tar_single_file():
+    data = _make_tar({"hello.txt": "world"})
+    files = _extract_tar(data)
+    assert files == {"hello.txt": "world"}
+
+
+def test_make_tar_multiple_files():
+    data = _make_tar({
+        "a.txt": "aaa",
+        "sub/b.txt": "bbb",
+    })
+    files = _extract_tar(data)
+    assert files["a.txt"] == "aaa"
+    assert files["sub/b.txt"] == "bbb"
+
+
+def test_make_tar_binary_content():
+    data = _make_tar({"bin.dat": b"\x00\x01\x02"})
+    with tarfile.open(fileobj=BytesIO(data)) as tar:
+        content = tar.extractfile("bin.dat").read()
+    assert content == b"\x00\x01\x02"
+
+
+def test_make_tar_empty():
+    data = _make_tar({})
+    with tarfile.open(fileobj=BytesIO(data)) as tar:
+        assert tar.getmembers() == []
+
+
+def test_inject_files_no_extras():
+    """No keys, repos, or defaults — nothing should be injected."""
+    container = MagicMock()
+    request = BuildRequest(
+        version="1.2.3",
+        target="testtarget/testsubtarget",
+        profile="testprofile",
+    )
+    inject_files(container, request)
+    container.put_archive.assert_not_called()
+
+
+def test_inject_files_with_defaults():
+    container = MagicMock()
+    request = BuildRequest(
+        version="1.2.3",
+        target="testtarget/testsubtarget",
+        profile="testprofile",
+        defaults="echo hello",
+    )
+    inject_files(container, request)
+    container.put_archive.assert_called_once()
+
+    call_args = container.put_archive.call_args
+    assert call_args[0][0] == "/builder/"
+    files = _extract_tar(call_args[0][1])
+    assert "asu-files/etc/uci-defaults/99-asu-defaults" in files
+    assert files["asu-files/etc/uci-defaults/99-asu-defaults"] == "echo hello"
+
+
+def test_inject_files_with_repositories():
+    container = MagicMock()
+    request = BuildRequest(
+        version="1.2.3",
+        target="testtarget/testsubtarget",
+        profile="testprofile",
+        repositories={},
+    )
+    inject_files(container, request)
+    container.put_archive.assert_not_called()
+
+
+def test_inject_files_with_keys():
+    container = MagicMock()
+    # Valid usign public key (base64 of 2-byte pkalg + 8-byte keynum + 32-byte pubkey)
+    import base64
+
+    key_data = base64.b64encode(b"\x00" * 42).decode()
+    request = BuildRequest(
+        version="1.2.3",
+        target="testtarget/testsubtarget",
+        profile="testprofile",
+        repository_keys=[key_data],
+    )
+    inject_files(container, request)
+    container.put_archive.assert_called_once()
+
+    call_args = container.put_archive.call_args
+    assert call_args[0][0] == "/builder/"
+    files = _extract_tar(call_args[0][1])
+    # Should have one key file under keys/
+    key_files = [f for f in files if f.startswith("keys/")]
+    assert len(key_files) == 1
+    assert key_data in files[key_files[0]]
+
+
+def test_inject_files_defaults_and_keys():
+    """Multiple inject types should result in multiple put_archive calls."""
+    container = MagicMock()
+    import base64
+
+    key_data = base64.b64encode(b"\x00" * 42).decode()
+    request = BuildRequest(
+        version="1.2.3",
+        target="testtarget/testsubtarget",
+        profile="testprofile",
+        defaults="echo test",
+        repository_keys=[key_data],
+    )
+    inject_files(container, request)
+    assert container.put_archive.call_count == 2

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,6 +1,8 @@
-from asu.config import settings
+import tempfile
+from pathlib import Path
 
-# store_path = settings.public_path / "store"
+from asu.config import settings
+from asu.store import LocalStore
 
 
 def test_store_content_type_img(client):
@@ -34,3 +36,56 @@ def test_store_file_missing(client):
 
     headers = response.headers
     assert headers["Content-Type"] != "application/octet-stream"
+
+
+def test_local_store_upload_file():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        settings.public_path = Path(tmpdir)
+        store = LocalStore()
+
+        src = Path(tmpdir) / "image.bin"
+        src.write_bytes(b"firmware data")
+
+        store.upload_file(src, "abc123/image.bin")
+
+        dest = Path(tmpdir) / "store" / "abc123" / "image.bin"
+        assert dest.is_file()
+        assert dest.read_bytes() == b"firmware data"
+
+
+def test_local_store_upload_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        settings.public_path = Path(tmpdir)
+        store = LocalStore()
+
+        build_dir = Path(tmpdir) / "build"
+        build_dir.mkdir()
+        (build_dir / "image.bin").write_bytes(b"fw1")
+        (build_dir / "profiles.json").write_text("{}")
+
+        store.upload_dir(build_dir, "abc123")
+
+        store_dir = Path(tmpdir) / "store" / "abc123"
+        assert (store_dir / "image.bin").read_bytes() == b"fw1"
+        assert (store_dir / "profiles.json").read_text() == "{}"
+
+
+def test_local_store_exists():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        settings.public_path = Path(tmpdir)
+        store = LocalStore()
+
+        assert not store.exists("abc123/image.bin")
+
+        (Path(tmpdir) / "store" / "abc123").mkdir(parents=True)
+        (Path(tmpdir) / "store" / "abc123" / "image.bin").touch()
+
+        assert store.exists("abc123/image.bin")
+
+
+def test_local_store_get_url():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        settings.public_path = Path(tmpdir)
+        store = LocalStore()
+
+        assert store.get_url("abc123/image.bin") == "/store/abc123/image.bin"

--- a/uv.lock
+++ b/uv.lock
@@ -35,8 +35,9 @@ wheels = [
 [[package]]
 name = "asu"
 version = "0.0.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "fastapi", extra = ["standard"] },
     { name = "fastapi-cache2" },
     { name = "httpx" },
@@ -61,6 +62,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.13.0" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.32.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.119.0" },
@@ -79,6 +81,34 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.37.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "boto3"
+version = "1.42.78"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/2b/ebdad075934cf6bb78bf81fe31d83339bcd804ad6c856f7341376cbc88b6/boto3-1.42.78.tar.gz", hash = "sha256:cef2ebdb9be5c0e96822f8d3941ac4b816c90a5737a7ffb901d664c808964b63", size = 112789, upload-time = "2026-03-27T19:28:07.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/bb/1f6dade1f1e86858bef7bd332bc8106c445f2dbabec7b32ab5d7d118c9b6/boto3-1.42.78-py3-none-any.whl", hash = "sha256:480a34a077484a5ca60124dfd150ba3ea6517fc89963a679e45b30c6db614d26", size = 140556, upload-time = "2026-03-27T19:28:06.125Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.78"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/8e/cdb34c8ca71216d214e049ada2148ee08bcda12b1ac72af3a720dea300ff/botocore-1.42.78.tar.gz", hash = "sha256:61cbd49728e23f68cfd945406ab40044d49abed143362f7ffa4a4f4bd4311791", size = 15023592, upload-time = "2026-03-27T19:27:57.122Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/72/94bba1a375d45c685b00e051b56142359547837086a83861d76f6aec26f4/botocore-1.42.78-py3-none-any.whl", hash = "sha256:038ab63c7f898e8b5db58cb6a45e4da56c31dd984e7e995839a3540c735564ea", size = 14701729, upload-time = "2026-03-27T19:27:54.05Z" },
+]
 
 [[package]]
 name = "certifi"
@@ -535,6 +565,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -1075,6 +1114,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/1c/d7b67ab43f30013b47c12b42d1acd354c195351a3f7a1d67f59e54227ede/ruff-0.14.10-py3-none-win32.whl", hash = "sha256:104c49fc7ab73f3f3a758039adea978869a918f31b73280db175b43a2d9b51d6", size = 13196187, upload-time = "2025-12-18T19:29:19.006Z" },
     { url = "https://files.pythonhosted.org/packages/fb/9c/896c862e13886fae2af961bef3e6312db9ebc6adc2b156fe95e615dee8c1/ruff-0.14.10-py3-none-win_amd64.whl", hash = "sha256:466297bd73638c6bdf06485683e812db1c00c7ac96d4ddd0294a338c62fdc154", size = 14661283, upload-time = "2025-12-18T19:29:30.16Z" },
     { url = "https://files.pythonhosted.org/packages/74/31/b0e29d572670dca3674eeee78e418f20bdf97fa8aa9ea71380885e175ca0/ruff-0.14.10-py3-none-win_arm64.whl", hash = "sha256:e51d046cf6dda98a4633b8a8a771451107413b0f07183b2bef03f075599e44e6", size = 13729839, upload-time = "2025-12-18T19:28:48.636Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces significant improvements to the build process, storage backend flexibility, and statistics reporting in the project. The main highlights are a switch from bind mounts to in-memory file injection for container builds, the addition of S3-compatible storage support, and new API/statistics endpoints for monitoring usage and package popularity. Several configuration options and TTL defaults have also been updated for better operational control.

**Build process improvements:**

* Replaces bind mounts with direct file injection into containers using in-memory tar archives via `put_archive`, improving portability and security. This affects how repository keys, repositories, and default files are injected for builds (`asu/build.py`). [[1]](diffhunk://#diff-fb93dc85c05b28607ca4ec6a46f0b24a96edcceddeea3c1f59286927e7da65eaR64-R127) [[2]](diffhunk://#diff-fb93dc85c05b28607ca4ec6a46f0b24a96edcceddeea3c1f59286927e7da65eaL130-R200)
* Adds a `_cleanup_container` utility to ensure containers are always killed and removed, even on errors, reducing resource leaks (`asu/build.py`). [[1]](diffhunk://#diff-fb93dc85c05b28607ca4ec6a46f0b24a96edcceddeea3c1f59286927e7da65eaR64-R127) [[2]](diffhunk://#diff-fb93dc85c05b28607ca4ec6a46f0b24a96edcceddeea3c1f59286927e7da65eaL321-R345)
* Refines build command construction and ensures correct handling of custom rootfs size and defaults (`asu/build.py`).

**Storage backend enhancements:**

* Introduces support for S3-compatible storage backends, configurable via new settings. The build output is uploaded to the configured backend, and local build artifacts are cleaned up if not using local storage (`asu/build.py`, `asu/config.py`, `asu/main.py`). [[1]](diffhunk://#diff-fb93dc85c05b28607ca4ec6a46f0b24a96edcceddeea3c1f59286927e7da65eaL414-R450) [[2]](diffhunk://#diff-d99fea653b0481a824cea138e6ee307f16f7982a941f13bf6fc2753ba00ce883R92-R105) [[3]](diffhunk://#diff-491c5ee0e7d6af1894d859d3dd8a9ab458af02c12a91ccc64ee8a444497ee49aL51-R68)
* The `/store/{path}` endpoint now redirects to an S3 URL if S3 is used, or serves files directly if using local storage (`asu/main.py`).

**Statistics and API improvements:**

* Adds `/stats/summary` and `/top-packages` API endpoints to provide build statistics and most requested packages, with optional branch filtering (`asu/routers/stats.py`). [[1]](diffhunk://#diff-4d80537f812df54e9b83dcf19f04d2994ccae0e48baab3c42bfb94df58220a6bR30-R56) [[2]](diffhunk://#diff-4d80537f812df54e9b83dcf19f04d2994ccae0e48baab3c42bfb94df58220a6bR153-R191)
* Adds a `/stats` HTML endpoint for a statistics page, and updates how build TTLs are selected based on request type (`asu/main.py`, `asu/routers/api.py`). [[1]](diffhunk://#diff-491c5ee0e7d6af1894d859d3dd8a9ab458af02c12a91ccc64ee8a444497ee49aR87-R97) [[2]](diffhunk://#diff-f72c97eb2750c245340b39390a4fec2e3394a8ac1ab7aa91f497149182c09928L220-R225)

**Configuration and defaults:**

* Updates several TTL and retention defaults for builds, failures, and unversioned builds for improved cache management (`asu/config.py`).

**Documentation and minor fixes:**

* Adds instructions for running Redis via Podman in the `README.md` (`README.md`).
* Minor CSS selector fix for header logo (`asu/static/style.css`).