### PR TITLE
Add support for APK feeds

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -9,15 +9,18 @@ from os import getenv
 from pathlib import Path
 from typing import Union
 from time import perf_counter
-from urllib.parse import urlparse
 
 from rq import get_current_job
-from rq.utils import parse_timeout
 from podman import errors
+from rq.utils import parse_timeout
 
 from asu.build_request import BuildRequest
 from asu.config import settings
 from asu.package_changes import apply_package_changes
+from asu.repositories import (
+    merge_repositories,
+    validate_repos,
+)
 from asu.store import LocalStore, get_store
 from asu.util import (
     add_timestamp,
@@ -39,26 +42,6 @@ from asu.util import (
 )
 
 log = logging.getLogger("rq.worker")
-
-
-def is_repo_allowed(repo_url: str, allow_list: list[str]) -> bool:
-    """Check if a repository URL is allowed by the allow list.
-
-    Uses proper URL parsing to prevent subdomain and userinfo bypasses
-    that affect naive prefix matching.
-    """
-    if not allow_list:
-        return False
-    parsed = urlparse(repo_url)
-    for allowed in allow_list:
-        allowed_parsed = urlparse(allowed)
-        if (
-            parsed.scheme == allowed_parsed.scheme
-            and parsed.hostname == allowed_parsed.hostname
-            and parsed.path.startswith(allowed_parsed.path.rstrip("/") + "/")
-        ):
-            return True
-    return False
 
 
 def _cleanup_container(container):
@@ -93,6 +76,16 @@ def _make_tar(files: dict[str, str | bytes]) -> bytes:
     return buf.getvalue()
 
 
+def _detect_apk_mode(container) -> bool:
+    """Detect whether the ImageBuilder uses apk or opkg.
+
+    Checks for the presence of /builder/repositories (apk) vs
+    /builder/repositories.conf (opkg) inside the running container.
+    """
+    rc, _, _ = run_cmd(container, ["test", "-f", "/builder/repositories"])
+    return rc == 0
+
+
 def inject_files(container, build_request, job=None):
     """Copy keys, repositories, and defaults into a running container.
 
@@ -101,28 +94,36 @@ def inject_files(container, build_request, job=None):
     """
     if build_request.repository_keys:
         files = {}
-        for key in build_request.repository_keys:
-            fingerprint = fingerprint_pubkey_usign(key)
-            files[f"keys/{fingerprint}"] = f"untrusted comment: {fingerprint}\n{key}"
-        container.put_archive("/builder/", _make_tar(files))
+        for i, key in enumerate(build_request.repository_keys):
+            if key.strip().startswith("-----BEGIN"):
+                files[f"keys/custom-{i}.pem"] = key
+            else:
+                fingerprint = fingerprint_pubkey_usign(key)
+                files[f"keys/{fingerprint}"] = (
+                    f"untrusted comment: {fingerprint}\n{key}"
+                )
+        if files:
+            container.put_archive("/builder/", _make_tar(files))
 
     if build_request.repositories:
-        repositories = ""
-        for name, repo in build_request.repositories.items():
-            if is_repo_allowed(repo, settings.repository_allow_list):
-                repositories += f"src/gz {name} {repo}\n"
-            elif job:
-                report_error(job, f"Repository {repo} not allowed")
-        repositories += "src imagebuilder file:packages\noption check_signature"
-        container.put_archive(
-            "/builder/", _make_tar({"repositories.conf": repositories})
-        )
+        allowed = validate_repos(build_request.repositories)
+        apk_mode = _detect_apk_mode(container)
+        repo_file = "repositories" if apk_mode else "repositories.conf"
+
+        base = ""
+        if build_request.repositories_mode == "append":
+            _, base, _ = run_cmd(container, ["cat", repo_file])
+
+        merged = merge_repositories(base, allowed, apk_mode)
+        container.put_archive("/builder/", _make_tar({repo_file: merged}))
 
     if build_request.defaults:
-        files = {
-            "asu-files/etc/uci-defaults/99-asu-defaults": build_request.defaults,
-        }
-        container.put_archive("/builder/", _make_tar(files))
+        container.put_archive(
+            "/builder/",
+            _make_tar(
+                {"asu-files/etc/uci-defaults/99-asu-defaults": build_request.defaults}
+            ),
+        )
 
 
 def _build(build_request: BuildRequest, job=None):
@@ -206,13 +207,12 @@ def _build(build_request: BuildRequest, job=None):
         cap_drop=["all"],
         no_new_privileges=True,
         privileged=False,
-        network_mode="pasta",
+        network_mode=settings.container_network_mode,
         environment=environment,
         image_volume_mode="ignore",
     )
     try:
         container.start()
-        inject_files(container, build_request, job)
 
         if is_snapshot_build(build_request.version):
             log.info("Running setup.sh for ImageBuilder")
@@ -221,6 +221,8 @@ def _build(build_request: BuildRequest, job=None):
             )
             if returncode:
                 report_error(job, f"Could not set up ImageBuilder ({returncode=})")
+
+        inject_files(container, build_request, job)
 
         returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(
             container, ["make", "info"]
@@ -281,9 +283,12 @@ def _build(build_request: BuildRequest, job=None):
 
         if settings.squid_cache and not is_snapshot_build(build_request.version):
             log.info("Disabling HTTPS for repositories")
+            repo_file = (
+                "repositories" if _detect_apk_mode(container) else "repositories.conf"
+            )
             run_cmd(
                 container,
-                ["sed", "-i", "s|https|http|g", "repositories.conf", "repositories"],
+                ["sed", "-i", "s|https|http|g", repo_file],
             )
 
         returncode, job.meta["stdout"], job.meta["stderr"] = run_cmd(

--- a/asu/build_request.py
+++ b/asu/build_request.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
 
@@ -147,6 +147,17 @@ class BuildRequest(BaseModel):
             """.strip()
         ),
     ] = {}
+    repositories_mode: Annotated[
+        Literal["append", "replace"],
+        Field(
+            description="""
+                How to apply the requested repositories (only used when
+                `repositories` is non-empty):
+                - `append`: merge into existing ImageBuilder repositories
+                - `replace`: replace existing repositories entirely (default)
+            """.strip()
+        ),
+    ] = "replace"
     repository_keys: Annotated[
         list[str],
         Field(

--- a/asu/config.py
+++ b/asu/config.py
@@ -75,6 +75,7 @@ class Settings(BaseSettings):
     base_container: str = "ghcr.io/openwrt/imagebuilder"
     container_socket_path: str = ""
     container_identity: str = ""
+    container_network_mode: str = "pasta"
     branches: dict = {
         "SNAPSHOT": {
             "path": "snapshots",

--- a/asu/repositories.py
+++ b/asu/repositories.py
@@ -1,0 +1,61 @@
+from urllib.parse import urlparse
+
+from asu.config import settings
+
+
+def is_repo_allowed(repo_url: str, allow_list: list[str]) -> bool:
+    """Check if a repository URL is allowed by the allow list.
+
+    Uses proper URL parsing to prevent subdomain and userinfo bypasses
+    that affect naive prefix matching.
+    """
+    if not allow_list:
+        return False
+    parsed = urlparse(repo_url)
+    for allowed in allow_list:
+        allowed_parsed = urlparse(allowed)
+        if (
+            parsed.scheme == allowed_parsed.scheme
+            and parsed.hostname == allowed_parsed.hostname
+            and parsed.path.startswith(allowed_parsed.path.rstrip("/") + "/")
+        ):
+            return True
+    return False
+
+
+def merge_repositories(
+    base_content: str, extra_repos: dict[str, str], apk_mode: bool
+) -> str:
+    """Append extra repositories to existing content.
+
+    For opkg (repositories.conf): entries are `src/gz <name> <url>`.
+    For apk (repositories): entries are plain URLs, one per line.
+    """
+    lines = [line for line in base_content.splitlines() if line.strip()]
+
+    for name, url in sorted(extra_repos.items()):
+        if apk_mode:
+            lines.append(url)
+        else:
+            lines.append(f"src/gz {name} {url}")
+
+    if not apk_mode:
+        if not any("src imagebuilder file:packages" in line for line in lines):
+            lines.append("src imagebuilder file:packages")
+        if not any("option check_signature" in line for line in lines):
+            lines.append("option check_signature")
+
+    return "\n".join(lines) + "\n"
+
+
+def validate_repos(repositories: dict[str, str]) -> dict[str, str]:
+    """Filter repositories against the allow list.
+
+    Repositories are already validated at the API level, but this
+    provides defense-in-depth for the build worker.
+    """
+    return {
+        name: url
+        for name, url in repositories.items()
+        if is_repo_allowed(url, settings.repository_allow_list)
+    }

--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -8,6 +8,7 @@ from rq.job import Job
 from asu.build import build
 from asu.build_request import BuildRequest
 from asu.config import settings
+from asu.repositories import is_repo_allowed
 from asu.util import (
     add_timestamp,
     add_build_event,
@@ -87,6 +88,10 @@ def validate_request(
 
     if build_request.defaults and not settings.allow_defaults:
         return validation_failure("Handling `defaults` not enabled on server")
+
+    for url in build_request.repositories.values():
+        if not is_repo_allowed(url, settings.repository_allow_list):
+            return validation_failure(f"Repository not allowed: {url}")
 
     if build_request.distro not in get_distros():
         return validation_failure(f"Unsupported distro: {build_request.distro}")

--- a/asu/util.py
+++ b/asu/util.py
@@ -182,6 +182,7 @@ def get_request_hash(build_request: BuildRequest) -> str:
                 str(build_request.rootfs_size_mb),
                 str(build_request.repository_keys),
                 str(build_request.repositories),
+                build_request.repositories_mode,
             ]
         ),
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,6 +51,7 @@ def test_api_build_inputs(client):
     assert request["client"] is None
     assert request["rootfs_size_mb"] is None
     assert request["diff_packages"] is False
+    assert request["repositories_mode"] == "replace"
 
 
 def test_api_build_version_code(client):
@@ -213,8 +214,8 @@ def test_api_build_request_hash(client):
         profile="testprofile",
     )
 
-    case12hash = "8d8e0aa2fd95bb75dba4aff4279dd6f976a40ad17300927d54b8a9a9b0576306"
-    case34hash = "6b1645013216da39ee09deae75b87b0636f3c50648b037750b0a80448ce5c7ca"
+    case12hash = "1c4a79c6b711a576996cf9a5e7046a4581008c4466574096266f0e6ea4208fbc"
+    case34hash = "c5a849e05b60611b465042594fc3489a44f7695c3d09e36433a577ee772ad7b7"
 
     # Case 1 - diff_packages=True, first package ordering
     json["diff_packages"] = True
@@ -722,7 +723,7 @@ def test_api_build_defaults_filled_allowed(app):
     data = response.json()
     assert (
         data["request_hash"]
-        == "9c8d0cd7d9ec208a233b954edb20c3c20b5c11103bb7f5f1ebface565f8c6720"
+        == "ba50558496f8fead41e8d5bc72afd1ad7d27bc053afb550a8bf6ee3bbcc64952"
     )
 
 
@@ -761,3 +762,72 @@ def test_api_stats(client):
     assert response.status_code == 200
     data = response.json()
     assert data["queue_length"] == 0
+
+
+@pytest.mark.slow
+def test_api_build_external_apk_repo(app):
+    """Build with an external apk repository (LibreMesh) and signing key.
+
+    Uses 25.12.2 (apk-based) with x86/64 target and the LibreMesh feed.
+    The lime-system package should appear in the manifest.
+    """
+    settings.upstream_url = "https://downloads.openwrt.org"
+    settings.repository_allow_list = ["https://raw.githubusercontent.com/libremesh/"]
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            target="x86/64",
+            version="25.12.2",
+            profile="generic",
+            packages=["lime-system"],
+            repositories={
+                "libremesh": "https://raw.githubusercontent.com/libremesh/lime-feed/gh-pages/master/openwrt-25.12/x86_64/packages.adb",
+            },
+            repository_keys=[
+                "-----BEGIN PUBLIC KEY-----\n"
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdFJZ2qVti49Ol8LJZYuxgOCLowBS\n"
+                "8bI86a7zqhSbs5yon3JON7Yee7CQOgqwPOX5eMALGOu8iFGAqIRx5YjfYA==\n"
+                "-----END PUBLIC KEY-----\n"
+            ],
+            repositories_mode="append",
+        ),
+    )
+
+    data = response.json()
+    assert response.status_code == 200, data.get("stderr", data.get("detail", ""))[
+        :2000
+    ]
+    assert "lime-system" in data["manifest"]
+
+
+@pytest.mark.slow
+def test_api_build_external_opkg_repo(app):
+    """Build with an external opkg repository (LibreMesh).
+
+    Uses 23.05.5 (opkg-based) with the LibreMesh feed and its usign
+    public key. The lime-system package should appear in the manifest.
+    """
+    settings.upstream_url = "https://downloads.openwrt.org"
+    settings.repository_allow_list = ["https://raw.githubusercontent.com/libremesh/"]
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            target="ath79/generic",
+            version="23.05.5",
+            profile="8dev_carambola2",
+            packages=["lime-system"],
+            repositories={
+                "libremesh": "https://raw.githubusercontent.com/libremesh/lime-feed/gh-pages/2024.1",
+            },
+            repository_keys=[
+                "RWSnGzyChavSiyQ+vLk3x7F0NqcLa4kKyXCdriThMhO78ldHgxGljM/8",
+            ],
+            repositories_mode="append",
+        ),
+    )
+
+    data = response.json()
+    assert response.status_code == 200
+    assert "lime-system" in data["manifest"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -765,12 +765,8 @@ def test_api_stats(client):
 
 
 @pytest.mark.slow
-def test_api_build_external_apk_repo(app):
-    """Build with an external apk repository (LibreMesh) and signing key.
-
-    Uses 25.12.2 (apk-based) with x86/64 target and the LibreMesh feed.
-    The lime-system package should appear in the manifest.
-    """
+def test_api_build_libremesh_apk(app):
+    """Build with LibreMesh apk repository (25.12.2, x86/64)."""
     settings.upstream_url = "https://downloads.openwrt.org"
     settings.repository_allow_list = ["https://raw.githubusercontent.com/libremesh/"]
     client = TestClient(app)
@@ -802,12 +798,8 @@ def test_api_build_external_apk_repo(app):
 
 
 @pytest.mark.slow
-def test_api_build_external_opkg_repo(app):
-    """Build with an external opkg repository (LibreMesh).
-
-    Uses 23.05.5 (opkg-based) with the LibreMesh feed and its usign
-    public key. The lime-system package should appear in the manifest.
-    """
+def test_api_build_libremesh_opkg(app):
+    """Build with LibreMesh opkg repository (23.05.5, ath79)."""
     settings.upstream_url = "https://downloads.openwrt.org"
     settings.repository_allow_list = ["https://raw.githubusercontent.com/libremesh/"]
     client = TestClient(app)
@@ -829,5 +821,70 @@ def test_api_build_external_opkg_repo(app):
     )
 
     data = response.json()
-    assert response.status_code == 200
+    assert response.status_code == 200, data.get("stderr", data.get("detail", ""))[
+        :2000
+    ]
     assert "lime-system" in data["manifest"]
+
+
+@pytest.mark.slow
+def test_api_build_freifunk_apk(app):
+    """Build with Freifunk Weimarnetz apk repository (25.12.2, ath79)."""
+    settings.upstream_url = "https://downloads.openwrt.org"
+    settings.repository_allow_list = ["https://buildbot.weimarnetz.de/"]
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            target="ath79/generic",
+            version="25.12.2",
+            profile="8dev_carambola2",
+            packages=["weimarnetz-feed-apk"],
+            repositories={
+                "weimarnetz": "https://buildbot.weimarnetz.de/builds/brauhaus/packages/stable/25.12/ath79/generic/weimarnetz_packages/packages.adb",
+            },
+            repository_keys=[
+                "-----BEGIN PUBLIC KEY-----\n"
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzZWFJBl7JU/XlRXaU4duMoqnu/L1\n"
+                "aPZGMO349gtL2Wt3eo8fC2qcbnXV2FdcPXaySeY4RmbrlG1ehDonJfW7Jg==\n"
+                "-----END PUBLIC KEY-----\n"
+            ],
+            repositories_mode="append",
+        ),
+    )
+
+    data = response.json()
+    assert response.status_code == 200, data.get("stderr", data.get("detail", ""))[
+        :2000
+    ]
+    assert "weimarnetz-feed-apk" in data["manifest"]
+
+
+@pytest.mark.slow
+def test_api_build_freifunk_opkg(app):
+    """Build with Freifunk Weimarnetz opkg repository (24.10.6, ath79)."""
+    settings.upstream_url = "https://downloads.openwrt.org"
+    settings.repository_allow_list = ["https://buildbot.weimarnetz.de/"]
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            target="ath79/generic",
+            version="24.10.6",
+            profile="8dev_carambola2",
+            packages=["weimarnetz-feed-opkg"],
+            repositories={
+                "weimarnetz": "https://buildbot.weimarnetz.de/builds/brauhaus/packages/stable/24.10/ath79/generic/weimarnetz_packages",
+            },
+            repository_keys=[
+                "RWRIR91gqalV7vnWiH8RjngeXUohKt0VMGPVHNYPVPX3Ala/k6tdjuWC",
+            ],
+            repositories_mode="append",
+        ),
+    )
+
+    data = response.json()
+    assert response.status_code == 200, data.get("stderr", data.get("detail", ""))[
+        :2000
+    ]
+    assert "weimarnetz-feed-opkg" in data["manifest"]

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,56 @@
+from asu.repositories import merge_repositories
+
+
+def test_merge_opkg_appends():
+    base = "src/gz base https://example.com/base\noption check_signature\n"
+    merged = merge_repositories(
+        base,
+        {"custom": "https://example.com/custom"},
+        apk_mode=False,
+    )
+    assert "src/gz base https://example.com/base" in merged
+    assert "src/gz custom https://example.com/custom" in merged
+    assert "option check_signature" in merged
+    assert "src imagebuilder file:packages" in merged
+
+
+def test_merge_opkg_adds_required_lines():
+    merged = merge_repositories(
+        "",
+        {"custom": "https://example.com/custom"},
+        apk_mode=False,
+    )
+    assert "src imagebuilder file:packages" in merged
+    assert "option check_signature" in merged
+
+
+def test_merge_opkg_replace_mode():
+    merged = merge_repositories(
+        "",
+        {"foo": "https://example.com/foo", "bar": "https://example.com/bar"},
+        apk_mode=False,
+    )
+    assert "src/gz bar https://example.com/bar" in merged
+    assert "src/gz foo https://example.com/foo" in merged
+    assert "option check_signature" in merged
+
+
+def test_merge_apk_appends():
+    base = "https://example.com/a\nhttps://example.com/b\n"
+    merged = merge_repositories(
+        base,
+        {"x": "https://example.com/c"},
+        apk_mode=True,
+    )
+    assert "https://example.com/a" in merged
+    assert "https://example.com/b" in merged
+    assert "https://example.com/c" in merged
+
+
+def test_merge_apk_replace_mode():
+    merged = merge_repositories(
+        "",
+        {"x": "https://example.com/new"},
+        apk_mode=True,
+    )
+    assert "https://example.com/new" in merged

--- a/tests/test_build_inject.py
+++ b/tests/test_build_inject.py
@@ -4,9 +4,10 @@ Tests verify that _make_tar produces correct archives and that
 inject_files constructs the right file trees for the container.
 """
 
+import base64
 import tarfile
 from io import BytesIO
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from asu.build import _make_tar, inject_files
 from asu.build_request import BuildRequest
@@ -65,7 +66,8 @@ def test_inject_files_no_extras():
     container.put_archive.assert_not_called()
 
 
-def test_inject_files_with_defaults():
+@patch("asu.build._detect_apk_mode", return_value=False)
+def test_inject_files_with_defaults(mock_detect):
     container = MagicMock()
     request = BuildRequest(
         version="1.2.3",
@@ -83,7 +85,8 @@ def test_inject_files_with_defaults():
     assert files["asu-files/etc/uci-defaults/99-asu-defaults"] == "echo hello"
 
 
-def test_inject_files_with_repositories():
+@patch("asu.build._detect_apk_mode", return_value=False)
+def test_inject_files_with_repositories(mock_detect):
     container = MagicMock()
     request = BuildRequest(
         version="1.2.3",
@@ -95,11 +98,9 @@ def test_inject_files_with_repositories():
     container.put_archive.assert_not_called()
 
 
-def test_inject_files_with_keys():
+def test_inject_files_with_usign_keys():
+    """usign keys go to /builder/keys/."""
     container = MagicMock()
-    # Valid usign public key (base64 of 2-byte pkalg + 8-byte keynum + 32-byte pubkey)
-    import base64
-
     key_data = base64.b64encode(b"\x00" * 42).decode()
     request = BuildRequest(
         version="1.2.3",
@@ -113,17 +114,56 @@ def test_inject_files_with_keys():
     call_args = container.put_archive.call_args
     assert call_args[0][0] == "/builder/"
     files = _extract_tar(call_args[0][1])
-    # Should have one key file under keys/
     key_files = [f for f in files if f.startswith("keys/")]
     assert len(key_files) == 1
     assert key_data in files[key_files[0]]
 
 
-def test_inject_files_defaults_and_keys():
+def test_inject_files_with_pem_keys():
+    """PEM keys also go to /builder/keys/."""
+    container = MagicMock()
+    pem_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZI...\n-----END PUBLIC KEY-----\n"
+    request = BuildRequest(
+        version="25.12.2",
+        target="testtarget/testsubtarget",
+        profile="testprofile",
+        repository_keys=[pem_key],
+    )
+    inject_files(container, request)
+    container.put_archive.assert_called_once()
+
+    call_args = container.put_archive.call_args
+    assert call_args[0][0] == "/builder/"
+    files = _extract_tar(call_args[0][1])
+    pem_files = [f for f in files if f.endswith(".pem")]
+    assert len(pem_files) == 1
+    assert pem_key in files[pem_files[0]]
+
+
+def test_inject_files_mixed_keys():
+    """Both PEM and usign keys in one request go to /builder/keys/."""
+    container = MagicMock()
+    pem_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZI...\n-----END PUBLIC KEY-----\n"
+    usign_key = base64.b64encode(b"\x00" * 42).decode()
+    request = BuildRequest(
+        version="25.12.2",
+        target="testtarget/testsubtarget",
+        profile="testprofile",
+        repository_keys=[pem_key, usign_key],
+    )
+    inject_files(container, request)
+    container.put_archive.assert_called_once()
+
+    call_args = container.put_archive.call_args
+    assert call_args[0][0] == "/builder/"
+    files = _extract_tar(call_args[0][1])
+    assert len(files) == 2
+
+
+@patch("asu.build._detect_apk_mode", return_value=False)
+def test_inject_files_defaults_and_keys(mock_detect):
     """Multiple inject types should result in multiple put_archive calls."""
     container = MagicMock()
-    import base64
-
     key_data = base64.b64encode(b"\x00" * 42).decode()
     request = BuildRequest(
         version="1.2.3",

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -3,6 +3,7 @@
 import pytest
 
 from asu.build_request import BuildRequest
+from asu.config import settings
 
 
 def test_repo_name_rejects_newline():
@@ -125,3 +126,61 @@ def test_repo_url_accepts_http():
         repositories={"repo": "http://example.com/packages"},
     )
     assert req.repositories["repo"] == "http://example.com/packages"
+
+
+def test_repositories_mode_accepts_append_and_replace():
+    append_request = BuildRequest(
+        version="1.2.3",
+        target="testtarget/testsubtarget",
+        profile="testprofile",
+        repositories_mode="append",
+    )
+    replace_request = BuildRequest(
+        version="1.2.3",
+        target="testtarget/testsubtarget",
+        profile="testprofile",
+        repositories_mode="replace",
+    )
+    assert append_request.repositories_mode == "append"
+    assert replace_request.repositories_mode == "replace"
+
+
+def test_repositories_mode_rejects_invalid_value():
+    with pytest.raises(Exception):
+        BuildRequest(
+            version="1.2.3",
+            target="testtarget/testsubtarget",
+            profile="testprofile",
+            repositories_mode="invalid",
+        )
+
+
+def test_api_repositories_mode_rejects_invalid_value(client):
+    response = client.post(
+        "/api/v1/build",
+        json={
+            "version": "1.2.3",
+            "target": "testtarget/testsubtarget",
+            "profile": "testprofile",
+            "repositories_mode": "invalid",
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_api_repo_not_in_allow_list(client):
+    """Repositories not in the allow list must be rejected at the API level."""
+    settings.repository_allow_list = ["https://allowed.example.com/"]
+    response = client.post(
+        "/api/v1/build",
+        json={
+            "version": "1.2.3",
+            "target": "testtarget/testsubtarget",
+            "profile": "testprofile",
+            "repositories": {
+                "evil": "https://evil.example.com/packages",
+            },
+        },
+    )
+    assert response.status_code == 400
+    assert "not allowed" in response.json()["detail"]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,7 +7,7 @@ import pytest
 from podman import PodmanClient
 
 import asu.util
-from asu.build import is_repo_allowed
+from asu.repositories import is_repo_allowed
 from asu.build_request import BuildRequest
 from asu.util import (
     check_manifest,
@@ -71,8 +71,21 @@ def test_get_request_hash():
 
     assert (
         get_request_hash(request)
-        == "99ff721439cd696f7da259541a07d7bfc7eb6c45a844db532e0384b464e23f46"
+        == "525e19496bd8d47b9b63aa5fb2b2f5da467558893d39a42eb32210007fd57800"
     )
+
+
+def test_get_request_hash_includes_repositories_mode():
+    base = dict(
+        version="1.2.3",
+        target="testtarget/testsubtarget",
+        profile="testprofile",
+        repositories={"custom": "https://example.com/repo"},
+    )
+    append_hash = get_request_hash(BuildRequest(**base, repositories_mode="append"))
+    replace_hash = get_request_hash(BuildRequest(**base, repositories_mode="replace"))
+
+    assert append_hash != replace_hash
 
 
 def test_diff_packages():


### PR DESCRIPTION
This pull request introduces significant improvements to how external repositories are handled in build requests, including support for both opkg and apk repository formats, a new option to control repository merging behavior, and enhanced validation and testing. The changes refactor repository logic into a dedicated module, improve security through stricter validation, and add comprehensive tests for new functionality.

**Repository handling improvements:**

* Refactored repository logic out of `asu/build.py` into a new `asu/repositories.py` module, including `is_repo_allowed`, `merge_repositories`, and `validate_repos` functions for better modularity and maintainability. [[1]](diffhunk://#diff-fb93dc85c05b28607ca4ec6a46f0b24a96edcceddeea3c1f59286927e7da65eaL12-R23) [[2]](diffhunk://#diff-fb93dc85c05b28607ca4ec6a46f0b24a96edcceddeea3c1f59286927e7da65eaL44-L63) [[3]](diffhunk://#diff-d1fc8d84c3f98865466c722a4b277f1a27e27f957723b926bd05e9d3fe97d210R1-R61)
* Added support for both opkg (`repositories.conf`) and apk (`repositories`) repository formats, with automatic detection and correct merging/appending of repositories in the build container. [[1]](diffhunk://#diff-fb93dc85c05b28607ca4ec6a46f0b24a96edcceddeea3c1f59286927e7da65eaR79-R88) [[2]](diffhunk://#diff-fb93dc85c05b28607ca4ec6a46f0b24a96edcceddeea3c1f59286927e7da65eaL104-R126)
* Introduced the `repositories_mode` option in `BuildRequest` (`replace` or `append`), allowing users to control whether to merge with or replace the default repositories. [[1]](diffhunk://#diff-060a7890818ea4206806a936b067689f86848fcf9f10b59b02c899356a298c44R150-R160) [[2]](diffhunk://#diff-d530daadc47af55031cb723b6f87da361cfb538bfe8ceaee9d8af32bfce3b250R185)

**Validation and security enhancements:**

* Strengthened repository validation by enforcing allow-list checks both at the API level and within the build worker for defense-in-depth. [[1]](diffhunk://#diff-f72c97eb2750c245340b39390a4fec2e3394a8ac1ab7aa91f497149182c09928R11) [[2]](diffhunk://#diff-f72c97eb2750c245340b39390a4fec2e3394a8ac1ab7aa91f497149182c09928R92-R95) [[3]](diffhunk://#diff-d1fc8d84c3f98865466c722a4b277f1a27e27f957723b926bd05e9d3fe97d210R1-R61)
* Updated the build process to use a configurable container network mode via `settings.container_network_mode`. [[1]](diffhunk://#diff-fb93dc85c05b28607ca4ec6a46f0b24a96edcceddeea3c1f59286927e7da65eaL209-L215) [[2]](diffhunk://#diff-d99fea653b0481a824cea138e6ee307f16f7982a941f13bf6fc2753ba00ce883R78)

**Testing improvements:**

* Added comprehensive unit tests for repository merging logic in `tests/test_build.py` and for repository injection in the renamed `tests/test_build_inject.py`. [[1]](diffhunk://#diff-e7bc8c7d1837f65155df89f3b2662ca449b5800ee5d6b6b656c3564cb50d3e82R1-R56) [[2]](diffhunk://#diff-9a8dc5bb71a5615ede60f1adbfbcd51d54e8a05bf4f6b1bddc29203f83ae3299R7-R10) [[3]](diffhunk://#diff-9a8dc5bb71a5615ede60f1adbfbcd51d54e8a05bf4f6b1bddc29203f83ae3299L68-R70) [[4]](diffhunk://#diff-9a8dc5bb71a5615ede60f1adbfbcd51d54e8a05bf4f6b1bddc29203f83ae3299L86-R89) [[5]](diffhunk://#diff-9a8dc5bb71a5615ede60f1adbfbcd51d54e8a05bf4f6b1bddc29203f83ae3299L98-L102)
* Introduced new integration tests to verify external repository support for both apk and opkg, including signature key handling and manifest validation.

**Other changes:**

* Updated test cases and request hash calculation to account for the new `repositories_mode` field. [[1]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R54) [[2]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79L216-R218) [[3]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79L725-R726)

These changes collectively make repository management more flexible, secure, and testable in the build system.