### PR TITLE
feat(cache): revalidate cache

### DIFF
--- a/misc/nginx-cache.conf
+++ b/misc/nginx-cache.conf
@@ -40,8 +40,9 @@ server {
         proxy_set_header Accept-Encoding "";
 
         proxy_cache packages;
-        proxy_cache_valid 200 7d;
+        proxy_cache_valid 200 1m;
         proxy_cache_valid 404 1m;
+        proxy_cache_revalidate on;
         proxy_cache_use_stale error timeout updating;
         proxy_cache_lock on;
         proxy_cache_key $upstream_host$upstream_path;


### PR DESCRIPTION
To prevent mismatches between indexes and packages.

Valid time for 200 responses has been reduced to 1 minute. Squid used 0 seconds but with that setting Nginx does not cache the response.