### PR TITLE
feat: support ROOTFS_FILESYSTEM via new `filesystem` field

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -330,6 +330,12 @@ def _build(build_request: BuildRequest, job=None):
                 f"ROOTFS_PARTSIZE={build_request.rootfs_size_mb}"
             )
 
+        if build_request.filesystem:
+            log.debug("Restricting filesystem to %s", build_request.filesystem)
+            job.meta["build_cmd"].append(
+                f"ROOTFS_FILESYSTEM={build_request.filesystem}"
+            )
+
         log.debug("Build command: %s", job.meta["build_cmd"])
 
         job.meta["imagebuilder_status"] = "building_image"

--- a/asu/build_request.py
+++ b/asu/build_request.py
@@ -136,6 +136,33 @@ class BuildRequest(BaseModel):
             """.strip(),
         ),
     ] = None
+    filesystem: Annotated[
+        Literal[
+            "squashfs",
+            "ext4",
+            "ubifs",
+            "erofs",
+            "jffs2",
+            "jffs2-nand",
+            "targz",
+            "cpiogz",
+        ]
+        | None,
+        Field(
+            examples=["squashfs"],
+            description="""
+                Restrict the build to a single rootfs filesystem
+                (`ROOTFS_FILESYSTEM` in the ImageBuilder). By default the
+                ImageBuilder produces every filesystem it was built with
+                (typically squashfs and ext4). Requesting one specifically
+                reduces build time and disk usage, and works around cases
+                where one filesystem fails the build while another would
+                succeed. Requires OpenWrt with PR openwrt/openwrt#23425
+                The requested filesystem must be available in the target's
+                ImageBuilder.
+            """.strip(),
+        ),
+    ] = None
     repositories: Annotated[
         dict[
             Annotated[str, Field(pattern=REPO_NAME_PATTERN)],

--- a/asu/util.py
+++ b/asu/util.py
@@ -175,7 +175,7 @@ def get_request_hash(build_request: BuildRequest) -> str:
                 ),
                 get_manifest_hash(build_request.packages_versions),
                 str(build_request.diff_packages),
-                "",  # build_request.filesystem
+                build_request.filesystem or "",
                 get_str_hash(build_request.defaults),
                 str(build_request.rootfs_size_mb),
                 str(build_request.repository_keys),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,6 +50,7 @@ def test_api_build_inputs(client):
     assert request["defaults"] is None
     assert request["client"] is None
     assert request["rootfs_size_mb"] is None
+    assert request["filesystem"] is None
     assert request["diff_packages"] is False
     assert request["repositories_mode"] == "replace"
 
@@ -98,6 +99,36 @@ def test_api_build_rootfs_size_too_small(client):
     assert response.status_code == 422
     data = response.json()
     assert data["detail"][0]["msg"] == "Input should be greater than or equal to 1"
+
+
+def test_api_build_filesystem(client):
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            version="1.2.3",
+            target="testtarget/testsubtarget",
+            profile="testprofile",
+            packages=["test1", "test2"],
+            filesystem="squashfs",
+        ),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "ROOTFS_FILESYSTEM=squashfs" in data["build_cmd"]
+
+
+def test_api_build_filesystem_invalid(client):
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            version="1.2.3",
+            target="testtarget/testsubtarget",
+            profile="testprofile",
+            packages=["test1", "test2"],
+            filesystem="bogusfs",
+        ),
+    )
+    assert response.status_code == 422
 
 
 def test_api_build_rootfs_size_too_big(client):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -88,6 +88,20 @@ def test_get_request_hash_includes_repositories_mode():
     assert append_hash != replace_hash
 
 
+def test_get_request_hash_includes_filesystem():
+    base = dict(
+        version="1.2.3",
+        target="testtarget/testsubtarget",
+        profile="testprofile",
+    )
+    no_fs_hash = get_request_hash(BuildRequest(**base))
+    squashfs_hash = get_request_hash(BuildRequest(**base, filesystem="squashfs"))
+    ext4_hash = get_request_hash(BuildRequest(**base, filesystem="ext4"))
+
+    assert no_fs_hash != squashfs_hash
+    assert squashfs_hash != ext4_hash
+
+
 def test_diff_packages():
     assert diff_packages(["test1"], {"test1", "test2"}) == ["-test2", "test1"]
     assert diff_packages(["test1"], {"test1"}) == ["test1"]


### PR DESCRIPTION
Adds an optional `filesystem` field to BuildRequest (squashfs, ext4, ubifs, erofs, jffs2, jffs2-nand, targz, cpiogz). When set, the value is passed to ImageBuilder as `ROOTFS_FILESYSTEM=`, restricting the build to a single rootfs filesystem instead of producing all enabled ones.

Reduces build time and disk usage, and works around cases where one filesystem fails while another would succeed. Requires the OpenWrt side from openwrt/openwrt#23425; ignored on older ImageBuilders.

The request hash already reserved a slot for this field, so requests without `filesystem` produce the same hash as before and existing cached builds keep matching.