### PR TITLE
package-changes: remove kmod-lib-crc32c

### DIFF
--- a/asu/package_changes.py
+++ b/asu/package_changes.py
@@ -210,6 +210,8 @@ def apply_package_changes(build_request: BuildRequest):
     if build_request.version == "SNAPSHOT":  # Change "SNAPSHOT" to 26.x when needed.
         # https://github.com/openwrt/openwrt/commit/5b61a50244ebc82096f5949de294ad69851e1fd6
         _remove_if_present("kmod-nf-conntrack6")
+        # No specific commit, it was rolled into other kmods in kernel 6.18
+        _remove_if_present("kmod-lib-crc32c")
 
     # TODO: if we ever fully implement 'packages_versions', this needs rework
     for version, packages in language_packs.items():


### PR DESCRIPTION
This kmod no longer exists in Linux 6.18.  Even though it's strictly a dependency, and should not be included in build requests, many people nonetheless add it to Firmware Selector builds thus causing errors.  And since it is a dependency, removing it in pre-6.18 kernels causes no issues.

---
@aparcar  This is causing a lot of errors with snapshot requests.  I see 422 builds failed due to this as of this morning, so it would be nice to get in fairly soon.