### PR TITLE
Fix User-Agent crash, improve API correctness and reduce redundant calls

### DIFF
--- a/asu/build.py
+++ b/asu/build.py
@@ -86,11 +86,14 @@ def _detect_apk_mode(container) -> bool:
     return rc == 0
 
 
-def inject_files(container, build_request, job=None):
+def inject_files(container, build_request, job=None, apk_mode: bool | None = None):
     """Copy keys, repositories, and defaults into a running container.
 
     Uses put_archive to inject files directly — no bind mounts needed,
     so there are no host-path dependencies.
+
+    Args:
+        apk_mode: Pre-detected package manager mode (avoids redundant detection).
     """
     if build_request.repository_keys:
         files = {}
@@ -107,7 +110,8 @@ def inject_files(container, build_request, job=None):
 
     if build_request.repositories:
         allowed = validate_repos(build_request.repositories)
-        apk_mode = _detect_apk_mode(container)
+        if apk_mode is None:
+            apk_mode = _detect_apk_mode(container)
         repo_file = "repositories" if apk_mode else "repositories.conf"
 
         base = ""
@@ -214,15 +218,19 @@ def _build(build_request: BuildRequest, job=None):
             if returncode:
                 report_error(job, f"Could not set up ImageBuilder ({returncode=})")
 
-        inject_files(container, build_request, job)
+        # Detect the package manager only when something needs it: custom
+        # repositories (inject_files) or cache URL rewriting below.
+        apk_mode = None
+        if build_request.repositories or settings.cache_url:
+            apk_mode = _detect_apk_mode(container)
+
+        inject_files(container, build_request, job, apk_mode=apk_mode)
 
         # If a caching proxy is configured, rewrite repository URLs
         # from https://host/path to http://cache/host/path
         if settings.cache_url:
             cache_host = settings.cache_url.rstrip("/")
-            repo_file = (
-                "repositories" if _detect_apk_mode(container) else "repositories.conf"
-            )
+            repo_file = "repositories" if apk_mode else "repositories.conf"
             run_cmd(
                 container,
                 ["sed", "-i", f"s|https://|{cache_host}/|g", repo_file],

--- a/asu/main.py
+++ b/asu/main.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, UTC
 from pathlib import Path
 from typing import Union
 
@@ -126,14 +126,14 @@ def json_v1_profile(path: str, target: str, profile: str):
     ).json()
     profiles: dict = metadata.pop("profiles", {})
     if profile not in profiles:
-        return {}
+        raise HTTPException(status_code=404, detail=f"Profile not found: {profile}")
 
     return {
         **metadata,
         **profiles[profile],
         "id": profile,
-        "build_at": datetime.utcfromtimestamp(
-            int(metadata.get("source_date_epoch", 0))
+        "build_at": datetime.fromtimestamp(
+            int(metadata.get("source_date_epoch", 0)), UTC
         ).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
     }
 
@@ -150,7 +150,7 @@ def json_v1_latest():
 
 
 def generate_branches():
-    reload_versions(app)  # Do a reload in case .versions.json has updated.
+    # Caller is responsible for calling reload_versions() beforehand.
     branches = dict(**settings.branches)
 
     for branch in branches:
@@ -173,13 +173,15 @@ def generate_branches():
 
 @app.get("/json/v1/branches.json")
 def json_v1_branches():
+    reload_versions(app)
     return list(generate_branches().values())
 
 
 @app.get("/json/v1/overview.json")
 def json_v1_overview():
+    reload_versions(app)  # Single reload shared by both helpers.
     overview = {
-        "latest": generate_latest(),
+        "latest": app.latest,
         "branches": generate_branches(),
         "upstream_url": settings.upstream_url,
         "server": {
@@ -197,7 +199,7 @@ def json_v1_overview():
 
 @app.get("//{path:path}")
 def api_double_slash(path: str):
-    print(f"Redirecting double slash to single slash: {path}")
+    logging.info(f"Redirecting double slash to single slash: {path}")
     return RedirectResponse(f"/{path}", status_code=301)
 
 

--- a/asu/routers/api.py
+++ b/asu/routers/api.py
@@ -238,7 +238,7 @@ def api_v1_build_post(
 
     if build_request.client:
         client = build_request.client
-    elif user_agent.startswith("auc"):
+    elif user_agent and user_agent.startswith("auc"):
         client = user_agent.replace(" (", "/").replace(")", "")
     else:
         client = "unknown/0"

--- a/asu/util.py
+++ b/asu/util.py
@@ -31,9 +31,16 @@ log.propagate = False  # Suppress duplicate log messages.
 # Create a shared HTTP client
 _http_client = httpx.Client()
 
+# Cached Redis connections (one per decode mode)
+_redis_clients: dict[bool, redis.client.Redis] = {}
+
 
 def get_redis_client(unicode: bool = True) -> redis.client.Redis:
-    return redis.from_url(settings.redis_url, decode_responses=unicode)
+    if unicode not in _redis_clients:
+        _redis_clients[unicode] = redis.from_url(
+            settings.redis_url, decode_responses=unicode
+        )
+    return _redis_clients[unicode]
 
 
 def get_redis_ts():
@@ -44,9 +51,13 @@ def client_get(url: str) -> Response:
     return _http_client.get(url)
 
 
-def add_timestamp(key: str, labels: dict[str, str] = {}, value: int = 1) -> None:
+def add_timestamp(
+    key: str, labels: dict[str, str] | None = None, value: int = 1
+) -> None:
     if not settings.server_stats:
         return
+    if labels is None:
+        labels = {}
     log.debug(f"Adding timestamp to {key}: {labels}")
     get_redis_ts().add(
         key,
@@ -80,13 +91,21 @@ def add_build_event(event: str) -> None:
     add_timestamp(key, {"stats": "summary"})
 
 
+_queue: Queue | None = None
+
+
 def get_queue() -> Queue:
     """Return the current queue
 
     Returns:
         Queue: The current RQ work queue
     """
-    return Queue(connection=get_redis_client(False), is_async=settings.async_queue)
+    global _queue
+    if _queue is None:
+        _queue = Queue(
+            connection=get_redis_client(False), is_async=settings.async_queue
+        )
+    return _queue
 
 
 def get_branch(version_or_branch: str) -> dict[str, str]:
@@ -301,8 +320,7 @@ def diff_packages(
 def run_cmd(
     container: Container,
     command: list[str],
-    copy: list[str] = [],
-    environment: dict[str, str] = {},
+    copy: list[str] | None = None,
 ) -> tuple[int, str, str]:
     returncode, output = container.exec_run(command, demux=True, user="buildbot")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -929,3 +929,38 @@ def test_api_build_freifunk_opkg(app):
         :2000
     ]
     assert "weimarnetz-feed-opkg" in data["manifest"]
+
+
+def test_api_build_no_user_agent(client, monkeypatch):
+    """Requests without a User-Agent header must not crash the endpoint."""
+    monkeypatch.setattr(settings, "server_stats", False)
+    del client.headers["user-agent"]
+    response = client.post(
+        "/api/v1/build",
+        json=dict(
+            version="1.2.3",
+            target="testtarget/testsubtarget",
+            profile="Foobar",
+            packages=["test1", "test2"],
+        ),
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"].startswith("Unsupported profile: Foobar")
+
+
+def test_json_v1_profile(client):
+    response = client.get(
+        "/json/v1/releases/1.2.3/targets/testtarget/testsubtarget/testprofile.json"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == "testprofile"
+    assert data["build_at"].endswith("Z")
+
+
+def test_json_v1_profile_not_found(client):
+    response = client.get(
+        "/json/v1/releases/1.2.3/targets/testtarget/testsubtarget/Foobar.json"
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Profile not found: Foobar"


### PR DESCRIPTION
- Fixes: 500 on missing User-Agent and Return 404 for unknown profiles

- Replace deprecated `datetime.utcfromtimestamp()`

- Use `logging` instead of `print()`** in the double-slash redirect handler.

- Cache Redis connections** in `get_redis_client()` — previously every call
  to `get_queue()`, `add_timestamp()`, or `get_redis_ts()` opened a new TCP
  connection. A single `/build` POST could trigger 3+ connections.